### PR TITLE
Add method Client.me to get current permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- Add support for ReductStore API version 1.2 with method Client.me to get current
+  permissions, [PR-51](https://github.com/reductstore/reduct-js/pull/51)
+
 ### Changed:
 
 - Update documentation after rebranding, [PR-50](https://github.com/reductstore/reduct-py/pull/50)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ data stored in ReductStore.
 ## Features
 
 * Promise-based API for easy asynchronous programming
-* Support for ReductStore API version 1.1
+* Support for ReductStore API version 1.2
 * Token-based authentication for secure access to the database
 
 ## Getting Started

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -152,4 +152,13 @@ export class Client {
     async deleteToken(name: string): Promise<void> {
         await this.httpClient.delete(`/tokens/${name}`);
     }
+
+    /**
+     * Get current API token and its permissions
+     * @return {Promise<Token>} the token
+     */
+    async me(): Promise<Token> {
+        const {data} = await this.httpClient.get("/me");
+        return Token.parse(data);
+    }
 }

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -50,7 +50,7 @@ describe("Client", () => {
         await rec.write("somedata");
 
         const info: ServerInfo = await client.getInfo();
-        expect(info.version >= "1.1.0").toBeTruthy();
+        expect(info.version >= "1.2.0").toBeTruthy();
 
         expect(info.bucketCount).toEqual(2n);
         expect(info.usage).toEqual(16n);

--- a/test/Token.test.ts
+++ b/test/Token.test.ts
@@ -15,7 +15,7 @@ describe_token()("With Token API Client", () => {
             .then(() => done());
     });
 
-    test("should create a token", async () => {
+    it("should create a token", async () => {
         const permissions: TokenPermissions = {
             fullAccess: true,
             read: ["bucket_1"],
@@ -30,7 +30,7 @@ describe_token()("With Token API Client", () => {
         expect(tokenInfo.createdAt).toBeLessThanOrEqual(Date.now());
     });
 
-    test("should list tokens", async () => {
+    it("should list tokens", async () => {
         expect(await client.getTokenList()).toEqual([
             {name: "init-token", createdAt: expect.any(Number)}
         ]);
@@ -43,12 +43,18 @@ describe_token()("With Token API Client", () => {
         ]);
     });
 
-    test("should delete a token", async () => {
+    it("should delete a token", async () => {
         await client.createToken("token-1", {fullAccess: true});
         await client.deleteToken("token-1");
 
         expect(await client.getTokenList()).toEqual([
             {name: "init-token", createdAt: expect.any(Number)}
         ]);
+    });
+
+    it("should provide current API token and its permissions", async () => {
+        const token: Token = await client.me();
+        expect(token.name).toEqual("init-token");
+        expect(token.permissions).toEqual({fullAccess: true, read: [], write: []});
     });
 });


### PR DESCRIPTION
Closes #48 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #48 

### What is the new behavior?

Ive added `Client.me` method to get the current API token with its permission. It is the only feature which was added in ReductStore v1.2.

### Does this PR introduce a breaking change?

No

### Other information:
