### PR TITLE
Use x-reduct-error header for error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quick Start example and guide, [PR-54](https://github.com/reductstore/reduct-js/pull/54)
 - Support labels for read, write and querying, [PR-55](https://github.com/reductstore/reduct-js/pull/55)
 
+### Changed:
+
+- Use x-reduct-error header for error message, [PR-56](https://github.com/reductstore/reduct-js/pull/56)
+
 ### [1.2.0] - 2022-12-23
 
 ### Added:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reduct-js",
-  "version": "1.2.0",
+  "version": "1.3.0-pre",
   "description": "ReductStore Client SDK for Javascript/NodeJS/Typescript",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/APIError.ts
+++ b/src/APIError.ts
@@ -33,13 +33,7 @@ export class APIError {
         const resp = error.response;
         if (resp !== undefined) {
             apiError.status = resp.status;
-            if (resp.data !== undefined) {
-                // @ts-ignore
-                const {detail} = resp.data;
-                if (detail !== undefined) {
-                    apiError.message += ": " + detail;
-                }
-            }
+            apiError.message = resp.headers["x-reduct-error"];
         }
 
         return apiError;

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -87,7 +87,7 @@ describe("Client", () => {
     it("should get bucket with error", async () => {
         await expect(client.getBucket("NOTEXIST")).rejects.toMatchObject({
             status: 404,
-            message: "Request failed with status code 404: Bucket 'NOTEXIST' is not found"
+            message: "Bucket 'NOTEXIST' is not found"
         });
     });
 
@@ -119,7 +119,7 @@ describe("Client", () => {
         await client.createBucket("bucket");
         await expect(client.createBucket("bucket")).rejects.toMatchObject({
             status: 409,
-            message: "Request failed with status code 409: Bucket 'bucket' already exists",
+            message: "Bucket 'bucket' already exists",
         });
     });
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

ReductStorage sends an error message in the  `x-reduct-error ` message, but the SDK uses JSON body which is emptz for HEAD.

### What is the new behavior?

Use the header which works always.

### Does this PR introduce a breaking change?

No

### Other information:
