### PR TITLE
Add support for content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Quick Start example and guide, [PR-54](https://github.com/reductstore/reduct-js/pull/54)
 - Support labels for read, write and querying, [PR-55](https://github.com/reductstore/reduct-js/pull/55)
+- Support for content type of records, [PR-57](https://github.com/reductstore/reduct-js/pull/57)
 
 ### Changed:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ data stored in ReductStore.
 * Promise-based API for easy asynchronous programming
 * Support for ReductStore API version 1.3
 * Token-based authentication for secure access to the database
-* Labelin for read-write operations and querying
+* Labeling for read-write operations and querying
 
 ## Getting Started
 

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -8,10 +8,16 @@ import {LabelMap, ReadableRecord, WritableRecord} from "./Record";
 /**
  * Options for querying records
  */
-export interface QueryOptions  {
+export interface QueryOptions {
     ttl?: number;   // Time to live in seconds
     include?: LabelMap; //  include only record which have all these labels with the same value
     exclude?: LabelMap;  //  exclude record which have all these labels with the same value
+}
+
+export interface WriteOptions {
+    ts?: bigint;    // timestamp of the record
+    labels?: LabelMap;  // labels of the record
+    contentType?: string;  // content types of the record
 }
 
 /**
@@ -85,17 +91,26 @@ export class Bucket {
     /**
      * Start writing a record into an entry
      * @param entry name of the entry
-     * @param ts {BigInt} timestamp in microseconds for the record. It is current time if undefined.
+     * @param options {BigInt | WriteOptions} timestamp in microseconds for the record or options. It is current time if undefined.
      * @param labels {Record<string, LabelMap} labels for the record, should be a key-value map
      * @return Promise<WritableRecord>
      * @example
      * const record = await bucket.beginWrite("entry", 1203121n, {label1: "value1", label2: "value2"});
      * await record.write("Hello!);
      */
-    async beginWrite(entry: string, ts?: bigint, labels?: LabelMap): Promise<WritableRecord> {
-        ts ||= BigInt(Date.now() * 1000);
+    async beginWrite(entry: string, options?: bigint | WriteOptions): Promise<WritableRecord> {
+        let localOptions: WriteOptions = {};
+        if (options !== undefined) {
+            if (typeof (options) === "bigint") {
+                localOptions = {ts: options};
+            } else {
+                localOptions = options as WriteOptions;
+            }
+        }
+        localOptions.ts = localOptions.ts ?? BigInt(Date.now()) * 1000n;
 
-        return Promise.resolve(new WritableRecord(this.name, entry, ts, this.httpClient, labels ? labels : {}));
+
+        return Promise.resolve(new WritableRecord(this.name, entry, localOptions, this.httpClient));
     }
 
     /**
@@ -189,7 +204,8 @@ export class Bucket {
         return new ReadableRecord(BigInt(headers["x-reduct-time"]), BigInt(headers["content-length"]),
             headers["x-reduct-last"] == "1",
             data,
-            labels);
+            labels,
+            headers["content-type"],);
     }
 
 }

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -14,6 +14,9 @@ export interface QueryOptions {
     exclude?: LabelMap;  //  exclude record which have all these labels with the same value
 }
 
+/**
+ * Options for writing records
+ */
 export interface WriteOptions {
     ts?: bigint;    // timestamp of the record
     labels?: LabelMap;  // labels of the record
@@ -92,7 +95,6 @@ export class Bucket {
      * Start writing a record into an entry
      * @param entry name of the entry
      * @param options {BigInt | WriteOptions} timestamp in microseconds for the record or options. It is current time if undefined.
-     * @param labels {Record<string, LabelMap} labels for the record, should be a key-value map
      * @return Promise<WritableRecord>
      * @example
      * const record = await bucket.beginWrite("entry", 1203121n, {label1: "value1", label2: "value2"});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import {Client} from "./Client";
-import {Bucket} from "./Bucket";
+import {Bucket, QueryOptions, WriteOptions} from "./Bucket";
 import {APIError} from "./APIError";
 import {ServerInfo} from "./ServerInfo";
 import {BucketSettings, QuotaType} from "./BucketSettings";
@@ -10,6 +10,8 @@ import {Token, TokenPermissions} from "./Token";
 export {
     Client,
     Bucket,
+    QueryOptions,
+    WriteOptions,
     APIError,
     ServerInfo,
     BucketSettings,

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -121,11 +121,20 @@ describe("Bucket", () => {
 
     it("should read write and read labels along with records", async () => {
         const bucket: Bucket = await client.getBucket("bucket");
-        const record = await bucket.beginWrite("entry-1", undefined, {label1: "label1", label2: 100n, label3: true});
+        const record = await bucket.beginWrite("entry-1", {labels: {label1: "label1", label2: 100n, label3: true}});
         await record.write("somedata1");
 
         const readRecord = await bucket.beginRead("entry-1");
         expect(readRecord.labels).toEqual({label1: "label1", label2: "100", label3: "true"});
+    });
+
+    it("should read and write content type of records", async () => {
+        const bucket: Bucket = await client.getBucket("bucket");
+        const record = await bucket.beginWrite("entry-1", {contentType: "text/plain"});
+        await record.write("somedata1");
+
+        const readRecord = await bucket.beginRead("entry-1");
+        expect(readRecord.contentType).toEqual("text/plain");
     });
 
     it("should query records", async () => {
@@ -158,9 +167,9 @@ describe("Bucket", () => {
     it("should query records with labels", async () => {
         const bucket: Bucket = await client.getBucket("bucket");
 
-        let record = await bucket.beginWrite("entry-labels", undefined, {label1: "value1", label2: "value2"});
+        let record = await bucket.beginWrite("entry-labels", {labels: {label1: "value1", label2: "value2"}});
         await record.write("somedata1");
-        record = await bucket.beginWrite("entry-labels", undefined, {label1: "value1", label2: "value3"});
+        record = await bucket.beginWrite("entry-labels", {labels: {label1: "value1", label2: "value3"}});
         await record.write("somedata1");
 
         let records: ReadableRecord[] = await all(bucket.query("entry-labels", undefined, undefined,
@@ -170,7 +179,7 @@ describe("Bucket", () => {
         expect(records.length).toEqual(1);
         expect(records[0].labels).toEqual({label1: "value1", label2: "value2"});
 
-        records= await all(bucket.query("entry-labels", undefined, undefined,
+        records = await all(bucket.query("entry-labels", undefined, undefined,
             {
                 exclude: {label1: "value1", label2: "value2"},
             }));


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

Since 1.3 version, ReductStore supports Content-Type header for records. However, we don"t provide it in the SDK

### What is the new behavior?

I added WriteOption type to pass labels, timestamps, and content type.

### Does this PR introduce a breaking change?

No

### Other information:
