### PR TITLE
Fix sending Buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed:
+
+- Sending a record as Buffer, [PR-60](https://github.com/reductstore/reduct-js/pull/60)
+
 ## [1.4.0] - 2023-05-29
 
 ### Added:

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -12,6 +12,7 @@ import {BucketSettings} from "./BucketSettings";
 import {Bucket} from "./Bucket";
 import {Token, TokenPermissions} from "./Token";
 import {Readable} from "stream";
+import {Buffer} from "buffer";
 /**
  * Options
  */
@@ -44,7 +45,7 @@ export class Client {
                 "Authorization": `Bearer ${options.apiToken}`
             },
             transformRequest: [(data: any) => {
-                if (typeof data !== "object" || data instanceof Readable) {
+                if (typeof data !== "object" || data instanceof Readable || data instanceof Buffer) {
                     return data;
                 }
                 return bigJson.stringify(data);

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -45,12 +45,14 @@ export class Client {
                 "Authorization": `Bearer ${options.apiToken}`
             },
             transformRequest: [(data: any) => {
+                // very ugly hack to support big int in JSON
                 if (typeof data !== "object" || data instanceof Readable || data instanceof Buffer) {
                     return data;
                 }
                 return bigJson.stringify(data);
             }],
             transformResponse: [(data: any) => {
+                // very ugly hack to support big int in JSON
                 if (typeof data !== "string") {
                     return data;
                 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

The SDK uses hooks for encoding and decoding big integers , unfortunately it is  an error-prone approach. 
A record which is sent as Buffer where serialized into JSON. 

### What is the new behavior?

I've added a check for the Buffer type, but  it is just a work around.

### Does this PR introduce a breaking change?

No

### Other information:
