### PR TITLE
Support for `GET /api/v1/b/:bucket/:entry/batch` endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           path: /tmp/
 
       - name: Run ReductStore
-        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{ matrix.token }} -d reduct/store:{{ matrix.reductstore_version }}
+        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{ matrix.token }} -d reduct/store:${{ matrix.reductstore_version }}
 
       - name: Load image with tests
         run: |
@@ -64,7 +64,7 @@ jobs:
           name: image
           path: /tmp/
       - name: Run ReductStore
-        run: docker run -p 8383:8383 -v ${PWD}/data:/data -d reduct/store:{{ matrix.reductstore_version }}
+        run: docker run -p 8383:8383 -v ${PWD}/data:/data -d reduct/store:${{ matrix.reductstore_version }}
 
       - name: Load image with tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
     strategy:
       matrix:
         token: ["", "token"]
+        reductstore_version: [ "main", "latest" ]
+
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v2
@@ -39,7 +41,7 @@ jobs:
           path: /tmp/
 
       - name: Run ReductStore
-        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{ matrix.token }} -d reduct/store:main
+        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{ matrix.token }} -d reduct/store:{{ matrix.reductstore_version }}
 
       - name: Load image with tests
         run: |
@@ -54,6 +56,7 @@ jobs:
     strategy:
       matrix:
         example: ["HelloWorld.js", "QuickStart.js", "Subscription.js"]
+        reductstore_version: ["main", "latest"]
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v2
@@ -61,7 +64,7 @@ jobs:
           name: image
           path: /tmp/
       - name: Run ReductStore
-        run: docker run -p 8383:8383 -v ${PWD}/data:/data -d reduct/store:main
+        run: docker run -p 8383:8383 -v ${PWD}/data:/data -d reduct/store:{{ matrix.reductstore_version }}
 
       - name: Load image with tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- Support for `GET /api/v1/b/:bucket/:entry/batch` endpoint, [PR-62](https://github.com/reductstore/reduct-js/pull/62) 
+
 ## [1.4.1] - 2023-06-03
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ data stored in ReductStore.
 ## Features
 
 * Promise-based API for easy asynchronous programming
-* Support for ReductStore API version 1.4
+* Support for ReductStore API version 1.5
 * Token-based authentication for secure access to the database
 * Labeling for read-write operations and querying
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reduct-js",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reduct-js",
-      "version": "1.3.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -338,6 +338,7 @@ function parseCsvRow(row: string): { size: bigint, contentType?: string, labels:
     }
 
     const size = BigInt(items[0]);
+    // eslint-disable-next-line prefer-destructuring
     const contentType = items[1];
     const labels: LabelMap = {};
 

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -5,6 +5,7 @@ import {BucketInfo} from "./BucketInfo";
 import {EntryInfo} from "./EntryInfo";
 import {LabelMap, ReadableRecord, WritableRecord} from "./Record";
 import {APIError} from "./APIError";
+import {Readable} from "stream";
 
 /**
  * Options for querying records
@@ -193,26 +194,32 @@ export class Bucket {
         }
 
         const url = `/b/${this.name}/${entry}/q?` + params.join("&");
-        const resp = await this.httpClient.get(url);
-        const {id} = resp.data;
-        const {readRecord} = this;
-        yield* (async function* () {
-            while (true) {
-                try {
-                    const record = await readRecord(entry, undefined, id);
-                    yield record;
-                } catch (e) {
-                    if (e instanceof APIError && e.status === 204) {
-                        if (continueQuery) {
-                            await new Promise((resolve) => setTimeout(resolve, poolInterval * 1000));
-                            continue;
-                        }
-                        return;
+        const {data, headers} = await this.httpClient.get(url);
+        const {id} = data;
+        if (headers["x-reduct-api"] >= "1.5") {
+            yield* this.fetch_and_parse_batched_records(entry, id, continueQuery, poolInterval);
+        } else {
+            yield* this.fetch_and_parse_single_record(entry, id, continueQuery, poolInterval);
+
+        }
+    }
+
+    private async* fetch_and_parse_single_record(entry: string, id: string, continueQuery: boolean, poolInterval: number) {
+        while (true) {
+            try {
+                const record = await this.readRecord(entry, undefined, id);
+                yield record;
+            } catch (e) {
+                if (e instanceof APIError && e.status === 204) {
+                    if (continueQuery) {
+                        await new Promise((resolve) => setTimeout(resolve, poolInterval * 1000));
+                        continue;
                     }
-                    throw e;
+                    return;
                 }
+                throw e;
             }
-        })();
+        }
     }
 
     private async readRecord(entry: string, ts?: string, id?: string): Promise<ReadableRecord> {
@@ -248,4 +255,104 @@ export class Bucket {
             headers["content-type"],);
     }
 
+    private async* fetch_and_parse_batched_records(entry: string, id: string, continueQuery: boolean, poolInterval: number) {
+        while (true) {
+            try {
+                for await (const record of this.readBatchedRecords(entry, id)) {
+                    yield record;
+
+                    if (record.last) {
+                        return;
+                    }
+                }
+            } catch (e) {
+                if (e instanceof APIError && e.status === 204) {
+                    if (continueQuery) {
+                        await new Promise((resolve) => setTimeout(resolve, poolInterval * 1000));
+                        continue;
+                    }
+                    return;
+                }
+                throw e;
+            }
+        }
+    }
+
+    private async* readBatchedRecords(entry: string, id: string): AsyncGenerator<ReadableRecord> {
+        const {
+            status,
+            headers,
+            data,
+        } = await this.httpClient.get(`/b/${this.name}/${entry}/batch?q=${id}`, {responseType: "stream"});
+
+        if (status === 204) {
+            throw new APIError(headers["x-reduct-error"] ?? "No content", 204);
+        }
+
+        let count = 0;
+        const total = Object.entries(headers).reduce((acc, [key, _]) => key.startsWith("x-reduct-time-") ? acc + 1 : acc, 0);
+        let last = false;
+        for (const [key, value] of Object.entries(headers as Record<string, string>)) {
+            if (!key.startsWith("x-reduct-time-"))
+                continue;
+
+            const ts = key.substring(14);
+            const {size, contentType, labels} = parseCsvRow(value);
+
+            count += 1;
+            let stream;
+            if (count === total) {
+                if (headers["x-reduct-last"] === "true") {
+                    last = true;
+                }
+                stream = data;
+            } else {
+                stream = Readable.from(data.read(Number(size)));
+            }
+
+            yield new ReadableRecord(BigInt(ts), size, last, stream, labels, contentType);
+        }
+    }
+}
+
+function parseCsvRow(row: string): { size: bigint, contentType?: string, labels: LabelMap } {
+    const items: string[] = [];
+    let escaped = "";
+
+    for (const item of row.split(",")) {
+        if (item.startsWith("\"") && !escaped) {
+            escaped = item.substring(1);
+        }
+
+        if (escaped) {
+            if (item.endsWith("\"")) {
+                escaped = escaped.slice(0, -1);
+                items.push(escaped);
+                escaped = "";
+            } else {
+                escaped += item;
+            }
+        } else {
+            items.push(item);
+        }
+    }
+
+    const size = BigInt(items[0]);
+    const contentType = items[1];
+    const labels: LabelMap = {};
+
+    for (const item of items.slice(2)) {
+        if (!item.includes("=")) {
+            continue;
+        }
+
+        const [key, value] = item.split("=", 2);
+        labels[key] = value;
+    }
+
+    return {
+        size,
+        contentType,
+        labels,
+    };
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

Since version 1.5, ReductStore supports an endpoint with bathed records. However, the SDK doesn't support this.

### What is the new behavior?

The `Bucket.query` method checks the API version and if it's v1.5 it uses the batched request.

### Does this PR introduce a breaking change?

No

### Other information:
