### PR TITLE
Add `head` option to read only meta information about records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - Support for `GET /api/v1/b/:bucket/:entry/batch` endpoint, [PR-62](https://github.com/reductstore/reduct-js/pull/62) 
+- Option `head` to `Bucket.query` and `Bucket.beginRead`, [PR-63](https://github.com/reductstore/reduct-js/pull/63)
 
 ## [1.4.1] - 2023-06-03
 

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -6,6 +6,7 @@ import {EntryInfo} from "./EntryInfo";
 import {LabelMap, ReadableRecord, WritableRecord} from "./Record";
 import {APIError} from "./APIError";
 import {Readable} from "stream";
+import {Buffer} from "buffer";
 
 /**
  * Options for querying records
@@ -318,7 +319,7 @@ export class Bucket {
                 }
                 stream = data;
             } else {
-                stream = Readable.from(data.read(Number(size)) ?? "");
+                stream = Readable.from(head ? Buffer.from([]) : data.read(Number(size)));
             }
 
             yield new ReadableRecord(BigInt(ts), size, last, stream, labels, contentType);

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -318,7 +318,7 @@ export class Bucket {
                 }
                 stream = data;
             } else {
-                stream = Readable.from(data.read(Number(size)));
+                stream = Readable.from(data.read(Number(size)) ?? "");
             }
 
             yield new ReadableRecord(BigInt(ts), size, last, stream, labels, contentType);

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -155,7 +155,7 @@ describe("Bucket", () => {
 
     it.each([
         [false, ["somedata2", "somedata3"]],
-        [true, ["", "", ""]]
+        [true, ["", ""]]
     ])("should query records head=%p", async (head: boolean, contents: string[]) => {
         const bucket: Bucket = await client.getBucket("bucket");
         const records: ReadableRecord[] = await all(bucket.query("entry-2", undefined, undefined, {

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -87,12 +87,12 @@ describe("Bucket", () => {
         expect((await record.read()).toString()).toEqual("somedata3");
     });
 
-    it("should read a record by timestamp", async () => {
+    it.each([[false, "somedata2"], [true, ""]])("should read a record by timestamp (head=%p)", async (head: boolean, content: string) => {
         const bucket: Bucket = await client.getBucket("bucket");
-        const record = await bucket.beginRead("entry-2", 2000000n);
+        const record = await bucket.beginRead("entry-2", 2000000n, head);
 
         expect(record).toMatchObject({size: 9n, time: 2000000n, last: true});
-        expect(await record.read()).toEqual(Buffer.from("somedata2", "ascii"));
+        expect(await record.read()).toEqual(Buffer.from(content, "ascii"));
     });
 
     it("should read a record with error if timestamp is wrong", async () => {
@@ -153,18 +153,23 @@ describe("Bucket", () => {
         expect(readRecord.contentType).toEqual("text/plain");
     });
 
-    it("should query records", async () => {
+    it.each([
+        [false, ["somedata2", "somedata3"]],
+        [true, ["", "", ""]]
+    ])("should query records head=%p", async (head: boolean, contents: string[]) => {
         const bucket: Bucket = await client.getBucket("bucket");
-        const records: ReadableRecord[] = await all(bucket.query("entry-2"));
+        const records: ReadableRecord[] = await all(bucket.query("entry-2", undefined, undefined, {
+            head,
+        }));
 
         expect(records.length).toEqual(2);
         expect(records[0].time).toEqual(2_000_000n);
         expect(records[0].size).toEqual(9n);
-        expect(await records[0].read()).toEqual(Buffer.from("somedata2", "ascii"));
+        expect(await records[0].read()).toEqual(Buffer.from(contents[0], "ascii"));
 
         expect(records[1].time).toEqual(3_000_000n);
         expect(records[1].size).toEqual(9n);
-        expect(await records[1].read()).toEqual(Buffer.from("somedata3", "ascii"));
+        expect(await records[1].read()).toEqual(Buffer.from(contents[1], "ascii"));
     });
 
     it("should query records with parameters", async () => {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

Since v1.5, ReductStore provides HEAD method to read only meta information about records. The SDK doesn't support this.

### What is the new behavior?

I've implemented it as an option for the `Bucket.beginRead` and `Bucket.query` methods

### Does this PR introduce a breaking change?

No

### Other information:
