### PR TITLE
Add limit option to query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - `Bucket.remove_entry` method to remove entry from bucket, [PR-65](https://github.com/reductstore/reduct-js/pull/65)
+- `limit` option to `Bucket.query`, [PR-66](https://github.com/reductstore/reduct-js/pull/66)
 
 ## [1.5.0] - 2023-06-30
 

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -18,6 +18,7 @@ export interface QueryOptions {
     continuous?: boolean;  //  await for new records
     poolInterval?: number;  //  interval for pooling new records (only for continue=true)
     head?: boolean;  //  return only head of the record
+    limit?: number;  //  limit number of records
 }
 
 /**
@@ -207,6 +208,10 @@ export class Bucket {
                     if (options.ttl === undefined) {
                         params.push(`ttl=${poolInterval * 2}`);
                     }
+                }
+
+                if (options.limit !== undefined) {
+                    params.push(`limit=${options.limit}`);
                 }
 
                 head = options.head ?? false;

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -200,6 +200,12 @@ describe("Bucket", () => {
             .rejects.toHaveProperty("status", 404);
     });
 
+    it_api("1.6")("should query limited number of query", async () => {
+        const bucket: Bucket = await client.getBucket("bucket");
+        const records: ReadableRecord[] = await all(bucket.query("entry-2", 0n, undefined, {limit: 1}));
+        expect(records.length).toEqual(1);
+    });
+
     it("should query records with labels", async () => {
         const bucket: Bucket = await client.getBucket("bucket");
 


### PR DESCRIPTION
Closes #64

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #64 

### What is the new behavior?

I've added the `limit` option to query options.

### Does this PR introduce a breaking change?

No

### Other information:
