### PR TITLE
Add support for ReductStore API v1.7 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,6 +24,8 @@ build:
       - npm exec jsdoc2md lib/cjs/Client.js > docs/api/client.md
       - npm exec jsdoc2md lib/cjs/Bucket.js > docs/api/bucket.md
       - npm exec jsdoc2md lib/cjs/Record.js > docs/api/record.md
+      - npm exec jsdoc2md lib/cjs/Batch.js > docs/api/batch.md
+
 
       - rm node_modules -rf # not to waste time
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- `Bucket.beginBatch` and support for ReductStore API v1.7, [PR-68](https://github.com/reductstore/reduct-js/pull/68)
+
 ## [1.6.0] - 2023-08-15
 
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
-- `Bucket.beginBatch` and support for ReductStore API v1.7, [PR-68](https://github.com/reductstore/reduct-js/pull/68)
+- Support for ReductStore API v1.7: `isProvisioned` flag for `BucketInfo` and `Token` and `Bucket.beginWriteBatch`
+  method for batch writing, [PR-68](https://github.com/reductstore/reduct-js/pull/68)
 
 ## [1.6.0] - 2023-08-15
 
@@ -22,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
-- Support for `GET /api/v1/b/:bucket/:entry/batch` endpoint, [PR-62](https://github.com/reductstore/reduct-js/pull/62) 
+- Support for `GET /api/v1/b/:bucket/:entry/batch` endpoint, [PR-62](https://github.com/reductstore/reduct-js/pull/62)
 - Option `head` to `Bucket.query` and `Bucket.beginRead`, [PR-63](https://github.com/reductstore/reduct-js/pull/63)
 
 ## [1.4.1] - 2023-06-03

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
       - Client: docs/api/client.md
       - Bucket: docs/api/bucket.md
       - Record: docs/api/record.md
+      - Batch: docs/api/batch.md
   - ReductStore: https://www.reduct.store
 
 repo_name: reductstore/reduct-js

--- a/src/Batch.ts
+++ b/src/Batch.ts
@@ -1,0 +1,94 @@
+// @ts-ignore
+import {AxiosInstance} from "axios";
+import {LabelMap} from "./Record";
+import {APIError} from "./APIError";
+import Stream from "stream";
+
+/**
+ * Represents a batch of records for writing
+ */
+
+export class Batch {
+    private readonly bucketName: string;
+    private readonly entryName: string;
+    private readonly httpClient: AxiosInstance;
+
+    private readonly records: Map<bigint, {
+        data: Buffer,
+        contentType: string,
+        labels: LabelMap
+    }>;
+
+    public constructor(bucketName: string, entryName: string, httpClient: AxiosInstance) {
+        this.bucketName = bucketName;
+        this.entryName = entryName;
+        this.httpClient = httpClient;
+        this.records = new Map();
+    }
+
+
+    /**
+     * Add record to batch
+     * @param ts timestamp of record as a UNIX timestamp in microseconds
+     * @param data {Buffer | string} data to write
+     * @param contentType default: application/octet-stream
+     * @param labels default: {}
+     */
+    public add(ts: bigint, data: Buffer | string, contentType?: string, labels?: LabelMap): void {
+        const _contentType = contentType ?? "application/octet-stream";
+        const _labels = labels ?? {};
+        const _data: Buffer = data instanceof Buffer ? data : Buffer.from(data);
+        this.records.set(ts, {data: _data, contentType: _contentType, labels: _labels});
+    }
+
+    /**
+     * Write batch to entry
+     */
+    public async write(): Promise<Map<bigint, APIError>> {
+        const headers: Record<string, string> = {};
+        const chunks: Buffer[] = [];
+        let contentLength = 0;
+        for (const [ts, {data, contentType, labels}] of this.items()) {
+            contentLength += data.length;
+            chunks.push(data);
+            const headerName = `x-reduct-time-${ts}`;
+            let headerValue = `${data.length},${contentType}`;
+
+            for (const [key, value] of Object.entries(labels)) {
+                if (value.toString().includes(",")) {
+                    headerValue += `,${key}="${value}"`;
+                } else {
+                    headerValue += `,${key}=${value}`;
+                }
+            }
+
+            headers[headerName] = headerValue;
+        }
+
+        headers["Content-Length"] = contentLength.toString();
+        headers["Content-Type"] = "application/octet-stream";
+
+        const stream = Stream.Readable.from(chunks);
+        const response = await this.httpClient.post(`/b/${this.bucketName}/${this.entryName}/batch`, stream, {
+            headers: headers
+        });
+
+        const errors = new Map<bigint, APIError>();
+        for (const [key, value] of Object.entries(response.headers as Record<string, string>)) {
+            if (key.startsWith("x-reduct-error-")) {
+                const ts = BigInt(key.slice(15));
+                const [code, message] = value.split(",", 2);
+                errors.set(ts, new APIError(message, Number.parseInt(code)));
+            }
+        }
+
+        return errors;
+    }
+
+    /**
+     * Get records in batch sorted by timestamp
+     */
+    items(): IterableIterator<[bigint, { data: Buffer; contentType: string; labels: LabelMap }]> {
+        return new Map([...this.records.entries()].sort()).entries();
+    }
+}

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -7,6 +7,7 @@ import {LabelMap, ReadableRecord, WritableRecord} from "./Record";
 import {APIError} from "./APIError";
 import {Readable} from "stream";
 import {Buffer} from "buffer";
+import {Batch} from "./Batch";
 
 /**
  * Options for querying records
@@ -339,6 +340,14 @@ export class Bucket {
 
             yield new ReadableRecord(BigInt(ts), size, last, stream, labels, contentType);
         }
+    }
+
+    /**
+     * Create a new batch for writing records to the database.
+     * @param entry
+     */
+    async beginBatch(entry: string): Promise<Batch> {
+        return new Batch(this.name, entry, this.httpClient);
     }
 }
 

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -346,7 +346,7 @@ export class Bucket {
      * Create a new batch for writing records to the database.
      * @param entry
      */
-    async beginBatch(entry: string): Promise<Batch> {
+    async beginWriteBatch(entry: string): Promise<Batch> {
         return new Batch(this.name, entry, this.httpClient);
     }
 }

--- a/src/BucketInfo.ts
+++ b/src/BucketInfo.ts
@@ -40,7 +40,7 @@ export class BucketInfo {
             size: BigInt(bucket.size),
             oldestRecord: BigInt(bucket.oldest_record),
             latestRecord: BigInt(bucket.latest_record),
-            isProvisioned: bucket.is_provisioned
+            isProvisioned: bucket.is_provisioned ?? false
         };
     }
 }
@@ -51,5 +51,5 @@ type Original = {
     size: string;
     oldest_record: string;
     latest_record: string;
-    is_provisioned: boolean;
+    is_provisioned?: boolean;
 }

--- a/src/BucketInfo.ts
+++ b/src/BucketInfo.ts
@@ -27,6 +27,11 @@ export class BucketInfo {
      */
     readonly latestRecord: bigint = 0n;
 
+    /**
+     * Is the bucket provisioned, and you can't remove it or change its settings
+     */
+    readonly isProvisioned: boolean = false;
+
 
     static parse(bucket: Original): BucketInfo {
         return {
@@ -35,8 +40,16 @@ export class BucketInfo {
             size: BigInt(bucket.size),
             oldestRecord: BigInt(bucket.oldest_record),
             latestRecord: BigInt(bucket.latest_record),
+            isProvisioned: bucket.is_provisioned
         };
     }
 }
 
-type Original = { name: string; entry_count: string; size: string; oldest_record: string; latest_record: string; }
+type Original = {
+    name: string;
+    entry_count: string;
+    size: string;
+    oldest_record: string;
+    latest_record: string;
+    is_provisioned: boolean;
+}

--- a/src/Token.ts
+++ b/src/Token.ts
@@ -52,7 +52,7 @@ export class TokenPermissions {
 class OriginalTokenInfo {
     name = "";
     created_at = "";
-    is_provisioned = false;
+    is_provisioned? = false;
     permissions?: OriginalTokenPermission = undefined;
 }
 
@@ -84,7 +84,7 @@ export class Token {
         return {
             name: data.name,
             createdAt: Date.parse(data.created_at),
-            isProvisioned: data.is_provisioned,
+            isProvisioned: data.is_provisioned ?? false,
             permissions: data.permissions ? TokenPermissions.parse(data.permissions) : undefined
         };
     }

--- a/src/Token.ts
+++ b/src/Token.ts
@@ -52,6 +52,7 @@ export class TokenPermissions {
 class OriginalTokenInfo {
     name = "";
     created_at = "";
+    is_provisioned = false;
     permissions?: OriginalTokenPermission = undefined;
 }
 
@@ -70,6 +71,11 @@ export class Token {
     readonly createdAt: number = 0;
 
     /**
+     * Is the token provisioned, and you can't remove it or change it
+     */
+    readonly isProvisioned: boolean = false;
+
+    /**
      * Permissions of the token
      */
     readonly permissions?: TokenPermissions;
@@ -78,6 +84,7 @@ export class Token {
         return {
             name: data.name,
             createdAt: Date.parse(data.created_at),
+            isProvisioned: data.is_provisioned,
             permissions: data.permissions ? TokenPermissions.parse(data.permissions) : undefined
         };
     }

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -240,7 +240,7 @@ describe("Bucket", () => {
 
     it_api("1.7")("should write a batch of records", async () => {
         const bucket: Bucket = await client.getBucket("bucket");
-        const batch = await bucket.beginBatch("entry-10");
+        const batch = await bucket.beginWriteBatch("entry-10");
         batch.add(1000n, "somedata1");
         batch.add(2000n, "somedata2", "text/plain");
         batch.add(3000n, "somedata3", undefined, {label1: "value1", label2: "value2"});
@@ -277,7 +277,7 @@ describe("Bucket", () => {
     it_api("1.7")("should write a batch of records with errors", async () => {
         const bucket: Bucket = await client.getBucket("bucket");
 
-        const batch = await bucket.beginBatch("entry-1");
+        const batch = await bucket.beginWriteBatch("entry-1");
         batch.add(1000_000n, "somedata1");
         batch.add(2000n, "somedata2", "text/plain");
         batch.add(3000n, "somedata3", undefined, {label1: "value1", label2: "value2"});

--- a/test/Token.test.ts
+++ b/test/Token.test.ts
@@ -31,24 +31,41 @@ describe_token()("With Token API Client", () => {
     });
 
     it("should list tokens", async () => {
-        expect(await client.getTokenList()).toEqual([
-            {name: "init-token", createdAt: expect.any(Number)}
-        ]);
+        let tokens = await client.getTokenList();
+        expect(tokens).toHaveLength(1);
+        expect(tokens[0]).toMatchObject({
+            name: "init-token",
+            createdAt: expect.any(Number),
+            isProvisioned: false,
+        });
+
         await client.createToken("token-1", {fullAccess: true});
         await client.createToken("token-2", {fullAccess: false});
-        expect(await client.getTokenList()).toEqual([
-            {name: "init-token", createdAt: expect.any(Number)},
-            {name: "token-1", createdAt: expect.any(Number)},
-            {name: "token-2", createdAt: expect.any(Number)}
-        ]);
+
+        tokens = await client.getTokenList();
+        expect(tokens).toHaveLength(3);
+        expect(tokens[0]).toMatchObject({
+            name: "init-token",
+        });
+        expect(tokens[1]).toMatchObject({
+            name: "token-1",
+            isProvisioned: false,
+            permissions: {fullAccess: true, read: [], write: []},
+        });
+        expect(tokens[2]).toMatchObject({
+            name: "token-2",
+            isProvisioned: false,
+            permissions: {fullAccess: false, read: [], write: []},
+        });
+
     });
 
     it("should delete a token", async () => {
         await client.createToken("token-1", {fullAccess: true});
         await client.deleteToken("token-1");
 
-        expect(await client.getTokenList()).toEqual([
-            {name: "init-token", createdAt: expect.any(Number)}
+        expect(await client.getTokenList()).toMatchObject([
+            {name: "init-token"}
         ]);
     });
 

--- a/test/Token.test.ts
+++ b/test/Token.test.ts
@@ -50,12 +50,10 @@ describe_token()("With Token API Client", () => {
         expect(tokens[1]).toMatchObject({
             name: "token-1",
             isProvisioned: false,
-            permissions: {fullAccess: true, read: [], write: []},
         });
         expect(tokens[2]).toMatchObject({
             name: "token-2",
             isProvisioned: false,
-            permissions: {fullAccess: false, read: [], write: []},
         });
 
     });


### PR DESCRIPTION
Closes #67

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature 

### What is the current behavior?

See #67 

### What is the new behavior?

I've added the `Batch` class and the `Bucket.startWriteBatch` method for batch writing:

```javascript
        const bucket: Bucket = await client.getBucket("bucket");
        const batch = await bucket.beginWriteBatch("entry-10");
        batch.add(1000n, "somedata1");
        batch.add(2000n, "somedata2", "text/plain");
        batch.add(3000n, "somedata3", undefined, {label1: "value1", label2: "value2"});
        await batch.write();

``` 

The PR also provides the `isProvisioned` flag for the `Token` and `BucketInfo` classes.

### Does this PR introduce a breaking change?

No

### Other information:
