### PR TITLE
make isProvisioned optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed:
+
+- Backward compatibility, isProvisioned field is optional, [PR-69](https://github.com/reductstore/reduct-js/pull/69)
+
 ## [1.7.0] - 2023-10-06
 
 ### Added:

--- a/src/BucketInfo.ts
+++ b/src/BucketInfo.ts
@@ -30,7 +30,7 @@ export class BucketInfo {
     /**
      * Is the bucket provisioned, and you can't remove it or change its settings
      */
-    readonly isProvisioned: boolean = false;
+    readonly isProvisioned?: boolean = false;
 
 
     static parse(bucket: Original): BucketInfo {

--- a/src/Token.ts
+++ b/src/Token.ts
@@ -73,7 +73,7 @@ export class Token {
     /**
      * Is the token provisioned, and you can't remove it or change it
      */
-    readonly isProvisioned: boolean = false;
+    readonly isProvisioned?: boolean = false;
 
     /**
      * Permissions of the token


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bugfix

### What is the current behavior?

The backward compatibility was broken in v1.7 because the `isProvisioned` field wasn't optional

### What is the new behavior?

The field is optional now

### Does this PR introduce a breaking change?

No

### Other information:
