### PR TITLE
RS-56: Fix queering batched records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.2] - 2023-10-28
+
+### Fixed:
+
+- RS-56: Queering batched records, [PR-71](https://github.com/reductstore/reduct-js/pull/71)
+
 ## [1.7.1] - 2023-10-11
 
 ### Fixed:


### PR DESCRIPTION
Closes #70 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #70 

### What is the new behavior?

The problem was that the `Stream.Readable.read` was misused and worked only for small records. I've fixed the bug and added a test with querying records of 1 Mb. 


### Does this PR introduce a breaking change?

No

### Other information:
