### PR TITLE
Fix  `MaxListenersExceededWarning` warn in `Bucket.query` method

### DIFF
--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -338,17 +338,19 @@ export class Bucket {
                 let buffer = Buffer.from([]);
                 if (!head) {
                     buffer = await new Promise((resolve, reject) => {
+                        const err_handler = (err: any) => {
+                            reject(err);
+                        };
                         data.on("readable", function handler() {
                             const chunk = data.read(Number(size));
                             if (chunk !== null) {
                                 resolve(chunk);
                                 data.off("readable", handler);
+                                data.off("error", err_handler);
                             }
                         });
 
-                        data.on("error", (err: any) => {
-                            reject(err);
-                        });
+                        data.on("error", err_handler);
                     });
 
                 }


### PR DESCRIPTION
Closes #72 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #72 

### What is the new behavior?

When a record was received from a batch body, the promise removes the error handler.

### Does this PR introduce a breaking change?

No

### Other information:
