### PR TITLE
Update documentation link to new website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed:
+
+- docs: update link to new website, [PR-75](https://github.com/reductstore/reduct-js/pull/75)
+
 ## [1.7.4] - 2023-11-04
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ data stored in ReductStore.
 ## Features
 
 * Promise-based API for easy asynchronous programming
-* Support for [ReductStore HTTP API v1.7](https://docs.reduct.store/http-api)
+* Support for [ReductStore HTTP API v1.7](https://reduct.store/docs/http-api)
 * Token-based authentication for secure access to the database
 * Labeling for read-write operations and querying
 
 ## Getting Started
 
 To get started with the ReductStore Client SDK for JavaScript, you'll need to have ReductStore installed and running on
-your machine. You can find instructions for installing ReductStore [here](https://docs.reduct.store/#start-with-docker).
+your machine. You can find instructions for installing ReductStore [here](https://reduct.store/docs/#start-with-docker).
 
 Once you have ReductStore up and running, you can install the ReductStore Client SDK for JavaScript using npm:
 
@@ -59,4 +59,4 @@ For more examples, see the [Quick Start](https://js.reduct.store/en/latest/docs/
 ## References
 
 * [Documentation](https://js.reduct.store/)
-* [ReductStore HTTP API](https://docs.reduct.store/http-api)
+* [ReductStore HTTP API](https://reduct.store/docs/http-api)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -115,5 +115,5 @@ for await (const record of bucket.query("entry", startTs, stopTs)) {
 ## Next Steps
 
 You can find more detailed documentation and examples in [the Reference API section](./api/bucket.md). You can also
-refer to the [ReductStore HTTP API](https://docs.reduct.store/http-api) documentation for a complete reference
+refer to the [ReductStore HTTP API](https://reduct.store/docs/http-api) documentation for a complete reference
 of the available API calls.

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -53,7 +53,7 @@ describe("Bucket", () => {
         const info: BucketInfo = await bucket.getInfo();
 
         expect(info.name).toEqual("bucket");
-        expect(info.size).toEqual(27n);
+        expect(info.size).toEqual(125n);
         expect(info.entryCount).toEqual(2n);
         expect(info.oldestRecord).toEqual(1000_000n);
         expect(info.latestRecord).toEqual(3000_000n);
@@ -86,14 +86,14 @@ describe("Bucket", () => {
             name: "entry-1",
             oldestRecord: 1000000n,
             recordCount: 1n,
-            size: 9n
+            size: 41n
         }, {
             blockCount: 1n,
             latestRecord: 3000000n,
             name: "entry-2",
             oldestRecord: 2000000n,
             recordCount: 2n,
-            size: 18n
+            size: 84n
         }]);
     });
 

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -53,7 +53,7 @@ describe("Client", () => {
         expect(info.version >= "1.2.0").toBeTruthy();
 
         expect(info.bucketCount).toEqual(2n);
-        expect(info.usage).toEqual(16n);
+        expect(info.usage).toEqual(82n);
         expect(info.uptime).toBeGreaterThanOrEqual(0);
         expect(info.oldestRecord).toEqual(1000_000n);
         expect(info.latestRecord).toEqual(2000_000n);


### PR DESCRIPTION
With new website we need to change links from docs.reduct.store to reduct.store/docs