### PR TITLE
RS-224: Use https Agent only outside browser environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 lib/
 coverage/
+node_modules/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed:
+
+- RS-224: Use https Agent only outside browser environment, [PR-81](https://github.com/reductstore/reduct-js/pull/81/files)
 
 ## [1.9.1] - 2024-03-20
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -17,6 +17,7 @@ import {FullReplicationInfo, ReplicationInfo} from "./messages/ReplicationInfo";
 import {ReplicationSettings} from "./messages/ReplicationSettings";
 // @ts-ignore
 import {AxiosError, AxiosInstance, AxiosResponse} from "axios";
+import {AxiosRequestConfig} from "../node_modules/axios/index";
 import * as https from "https";
 
 /**
@@ -45,12 +46,9 @@ export class Client {
         );
 
         // http client with big int support in JSON
-        this.httpClient = axios.create({
+        const axiosConfig: AxiosRequestConfig = {
             baseURL: `${url}/api/v1`,
             timeout: options.timeout,
-            httpsAgent: new https.Agent({
-                rejectUnauthorized: options.verifySSL !== false
-            }),
 
             headers: {
                 "Authorization": `Bearer ${options.apiToken}`
@@ -75,7 +73,13 @@ export class Client {
                 }
                 return bigJson.parse(data);
             }]
-        });
+        };
+        if (typeof window === "undefined") {
+            axiosConfig.httpsAgent = new https.Agent({
+                rejectUnauthorized: options.verifySSL !== false
+            });
+        }
+        this.httpClient = axios.create(axiosConfig);
 
         this.httpClient.interceptors.response.use(
             (response: AxiosResponse) => response,


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The https.Agent class is part of Node.js's https module, which is not available in the browser. Browsers have their own way of handling HTTPS requests and do not expose a way to configure HTTP agents like Node.js does. 

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
