### PR TITLE
RS-261: Add `each_n` and `each_s` query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- RS-261: Add `each_n` and `each_s` query parameters, [PR-85](https://github.com/reductstore/reduct-js/pull/85)
+
 ### Changed:
 
 - RS-234: Integrate prettier to CI and reformat code, [PR-84](https://github.com/reductstore/reduct-js/pull/84)

--- a/README.md
+++ b/README.md
@@ -5,14 +5,13 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/reductstore/reduct-js/ci.yml?branch=main)](https://github.com/reductstore/reduct-js/actions)
 
 The ReductStore Client SDK for JavaScript is an asynchronous HTTP client for interacting with
-a [ReductStore](https://www.reduct.store) instance
-from a JavaScript application. It is written in TypeScript and provides a set of APIs for accessing and manipulating
+a [ReductStore](https://www.reduct.store) instance from a JavaScript application. It is written in TypeScript and provides a set of APIs for accessing and manipulating
 data stored in ReductStore.
 
 ## Features
 
 - Promise-based API for easy asynchronous programming
-- Support for [ReductStore HTTP API v1.9](https://wwww.reduct.store/docs/http-api)
+- Support for [ReductStore HTTP API v1.10](https://wwww.reduct.store/docs/http-api)
 - Token-based authentication for secure access to the database
 - Labeling for read-write operations and querying
 - Batch operations for efficient data processing

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -291,3 +291,17 @@ export class Client {
     await this.httpClient.delete(`/replications/${name}`);
   }
 }
+
+export const isCompatibale = (
+  min_version?: string,
+  current_version?: string,
+): boolean => {
+  if (min_version === undefined || current_version === undefined) {
+    return false;
+  }
+
+  const [a_major, a_minor] = min_version.split(".");
+  const [b_major, b_minor] = current_version.split(".");
+
+  return a_major === b_major && a_minor <= b_minor;
+};

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -300,8 +300,8 @@ export const isCompatibale = (
     return false;
   }
 
-  const [a_major, a_minor] = min_version.split(".");
-  const [b_major, b_minor] = current_version.split(".");
+  const [a_major, a_minor] = min_version.split(".").map((v) => parseInt(v));
+  const [b_major, b_minor] = current_version.split(".").map((v) => parseInt(v));
 
   return a_major === b_major && a_minor <= b_minor;
 };

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -49,7 +49,7 @@ describe("Client", () => {
     await rec.write("somedata");
 
     const info: ServerInfo = await client.getInfo();
-    expect(info.version >= "1.2.0").toBeTruthy();
+    expect(info.version >= "1.10.0").toBeTruthy();
 
     expect(info.bucketCount).toEqual(2n);
     expect(info.usage).toEqual(102n);

--- a/test/Helpers.ts
+++ b/test/Helpers.ts
@@ -42,7 +42,7 @@ export const makeClient = (): Client => {
 export const it_api = (version: string) => {
   const resp = request("HEAD", "http://localhost:8383/api/v1/alive");
   const api_version = resp.headers["x-reduct-api"] ?? "0.0";
-  if (isCompatibale(version, api_version)) {
+  if (isCompatibale(version, api_version.toString())) {
     return it;
   } else {
     return it.skip;

--- a/test/Helpers.ts
+++ b/test/Helpers.ts
@@ -1,5 +1,5 @@
 import { Bucket } from "../src/Bucket";
-import { Client } from "../src/Client";
+import { Client, isCompatibale } from "../src/Client";
 import * as process from "process";
 // @ts-ignore
 import request from "sync-request";
@@ -42,7 +42,7 @@ export const makeClient = (): Client => {
 export const it_api = (version: string) => {
   const resp = request("HEAD", "http://localhost:8383/api/v1/alive");
   const api_version = resp.headers["x-reduct-api"] ?? "0.0";
-  if (api_version >= version) {
+  if (isCompatibale(version, api_version)) {
     return it;
   } else {
     return it.skip;


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

I've added new `each_n` and `each_s` parameters to `QueryOptions` method.

### Related issues

reductstore/reductstore#465

### Does this PR introduce a breaking change?

No

### Other information:
