### PR TITLE
RS-319: fix name convention for replication settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed:
+
+- RS-319: fix name convention for replication settings, [PR-88](https://github.com/reductstore/reduct-js/pull/88)
+
 ## [1.10.0] - 2024-06-11
 
 ### Added:

--- a/src/messages/ReplicationSettings.ts
+++ b/src/messages/ReplicationSettings.ts
@@ -58,12 +58,12 @@ export class ReplicationSettings {
   /**
    * Replicate a record every S seconds
    */
-  readonly each_s?: number;
+  readonly eachS?: number;
 
   /**
    * Replicate every Nth record
    */
-  readonly each_n?: bigint;
+  readonly eachN?: bigint;
 
   static parse(data: OriginalReplicationSettings): ReplicationSettings {
     return {
@@ -74,8 +74,8 @@ export class ReplicationSettings {
       include: data.include,
       exclude: data.exclude,
       entries: data.entries,
-      each_s: data.each_s,
-      each_n: data.each_n ? BigInt(data.each_n) : data.each_n,
+      eachS: data.each_s,
+      eachN: data.each_n ? BigInt(data.each_n) : data.each_n,
     };
   }
 
@@ -85,6 +85,8 @@ export class ReplicationSettings {
       dst_bucket: data.dstBucket,
       dst_host: data.dstHost,
       dst_token: data.dstToken,
+      each_s: data.eachS,
+      each_n: data.eachN,
       ...data,
     };
   }

--- a/test/Replication.test.ts
+++ b/test/Replication.test.ts
@@ -90,15 +90,15 @@ describe("Replication", () => {
   it_api("1.10")("should support each_n and each_s", async () => {
     await client.createReplication("test-replication", {
       ...settings,
-      each_n: 10n,
-      each_s: 10,
+      eachN: 10n,
+      eachS: 10,
     });
 
     const replication = await client.getReplication("test-replication");
     expect(replication.settings).toMatchObject({
       ...settings,
-      each_n: 10n,
-      each_s: 10,
+      eachN: 10n,
+      eachS: 10,
     });
   });
 });


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The `each_n` and `each_s`  replication parameters don't follow the name convention. Renamed to `eachS` and `eachN`.

### Related issues

No

### Does this PR introduce a breaking change?

Yes, but it is not a critical part. 

### Other information:
