### PR TITLE
RS-394: Add query support for browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - RS-31: `Bucket.update` and `Bucket.beginUpdateBatch` methods for changing labels, [PR-89](https://github.com/reductstore/reduct-js/pull/89)
+- RS-394: Add query support for browser, [PR-90](https://github.com/reductstore/reduct-js/pull/90)
 
 ## [1.10.1] - 2024-07-01
 

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -1,5 +1,5 @@
 import Stream from "stream";
-import { Buffer } from 'buffer';
+import { Buffer } from "buffer";
 // @ts-ignore`
 import { AxiosInstance } from "axios";
 import { WriteOptions } from "./Bucket";
@@ -45,7 +45,7 @@ export class ReadableRecord {
       const chunks: Buffer[] = [];
       return new Promise((resolve, reject) => {
         (this.stream as Stream).on("data", (chunk: Buffer) =>
-          chunks.push(chunk)
+          chunks.push(chunk),
         );
         (this.stream as Stream).on("error", (err: Error) => reject(err));
         (this.stream as Stream).on("end", () => resolve(Buffer.concat(chunks)));

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -13,9 +13,10 @@ export class ReadableRecord {
   public readonly time: bigint;
   public readonly size: bigint;
   public readonly last: boolean;
-  public readonly stream: Stream | ArrayBuffer;
+  public readonly stream: Stream;
   public readonly labels: LabelMap = {};
   public readonly contentType: string | undefined;
+  private readonly arrayBuffer: ArrayBuffer | undefined;
 
   /**
    * Constructor which should be call from Bucket
@@ -25,9 +26,11 @@ export class ReadableRecord {
     time: bigint,
     size: bigint,
     last: boolean,
-    stream: Stream | ArrayBuffer,
+    stream: Stream,
     labels: LabelMap,
     contentType?: string,
+    arrayBuffer?: ArrayBuffer,
+
   ) {
     this.time = time;
     this.size = size;
@@ -35,32 +38,30 @@ export class ReadableRecord {
     this.stream = stream;
     this.labels = labels;
     this.contentType = contentType;
+    this.arrayBuffer = arrayBuffer;
   }
 
   /**
    * Read content of record
    */
   public async read(): Promise<Buffer> {
-    if (this.stream instanceof Stream) {
-      const chunks: Buffer[] = [];
-      return new Promise((resolve, reject) => {
-        (this.stream as Stream).on("data", (chunk: Buffer) =>
-          chunks.push(chunk),
-        );
-        (this.stream as Stream).on("error", (err: Error) => reject(err));
-        (this.stream as Stream).on("end", () => resolve(Buffer.concat(chunks)));
-      });
-    } else if (this.stream instanceof ArrayBuffer) {
+    if (this.arrayBuffer !== undefined) {
       return new Promise((resolve, reject) => {
         try {
-          resolve(Buffer.from(this.stream as ArrayBuffer));
+          resolve(Buffer.from(this.arrayBuffer as ArrayBuffer));
         } catch (error) {
           reject(error);
         }
       });
-    } else {
-      throw new Error("Stream is not supported");
     }
+    const chunks: Buffer[] = [];
+    return new Promise((resolve, reject) => {
+      (this.stream as Stream).on("data", (chunk: Buffer) =>
+        chunks.push(chunk),
+      );
+      (this.stream as Stream).on("error", (err: Error) => reject(err));
+      (this.stream as Stream).on("end", () => resolve(Buffer.concat(chunks)));
+    });
   }
 
   /**

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -30,7 +30,6 @@ export class ReadableRecord {
     labels: LabelMap,
     contentType?: string,
     arrayBuffer?: ArrayBuffer,
-
   ) {
     this.time = time;
     this.size = size;
@@ -56,9 +55,7 @@ export class ReadableRecord {
     }
     const chunks: Buffer[] = [];
     return new Promise((resolve, reject) => {
-      (this.stream as Stream).on("data", (chunk: Buffer) =>
-        chunks.push(chunk),
-      );
+      (this.stream as Stream).on("data", (chunk: Buffer) => chunks.push(chunk));
       (this.stream as Stream).on("error", (err: Error) => reject(err));
       (this.stream as Stream).on("end", () => resolve(Buffer.concat(chunks)));
     });

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -136,7 +136,7 @@ describe("Bucket", () => {
     const record = await bucket.beginWrite("big-blob");
     await record.write(Stream.Readable.from(bigBlob), bigBlob.length);
 
-    const readStream: Stream = (await bucket.beginRead("big-blob")).stream;
+    const readStream = (await bucket.beginRead("big-blob")).stream as Stream;
 
     const actual: Buffer = await new Promise((resolve, reject) => {
       const chunks: Buffer[] = [];

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -136,7 +136,7 @@ describe("Bucket", () => {
     const record = await bucket.beginWrite("big-blob");
     await record.write(Stream.Readable.from(bigBlob), bigBlob.length);
 
-    const readStream = (await bucket.beginRead("big-blob")).stream as Stream;
+    const readStream: Stream = (await bucket.beginRead("big-blob")).stream;
 
     const actual: Buffer = await new Promise((resolve, reject) => {
       const chunks: Buffer[] = [];

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -5,15 +5,15 @@ import { QuotaType } from "../src/messages/BucketSettings";
 import { cleanStorage, it_env, makeClient } from "./Helpers";
 
 test("Client should raise network error", async () => {
-  const client: Client = new Client("http://127.0.0.2:80");
+  const client: Client = new Client("http://127.0.0.1:9999");
 
   await expect(client.getInfo()).rejects.toMatchObject({
-    message: "connect ECONNREFUSED 127.0.0.2:80",
+    message: "connect ECONNREFUSED 127.0.0.1:9999",
   });
 });
 
 test("Client should raise timeout error", async () => {
-  const client: Client = new Client("http://somedomain.xxx", { timeout: 10 });
+  const client: Client = new Client("http://somedomain.com", { timeout: 10 });
 
   await expect(client.getInfo()).rejects.toMatchObject({
     message: "timeout of 10ms exceeded",


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Detect if the module is running in the browser
- Request ArrayBuffer instead of Stream when running in the browser
- Only fetch single records in the browser (not batch)
- Convert ArrayBuffer to Node.js Buffer (the read() method always gives a Node.js Buffer)

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:

Because the read function gives a Node.js Buffer object, applications running in the browser must install [stream-browserify](https://www.npmjs.com/package/stream-browserify).
