### PR TITLE
Fix hanging HEAD requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
       - name: Generate license
         run: echo '${{secrets.LICENSE_KEY}}' > lic.key
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Run ReductStore
         run: docker run -p 8383:8383 -v ${PWD}:/workdir
           --env RS_API_TOKEN=${{matrix.token}}
@@ -82,6 +88,12 @@ jobs:
         with:
           name: image
           path: /tmp/
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Run ReductStore
         run: docker run -p 8383:8383 -v ${PWD}/data:/data -d reduct/store:${{ matrix.reductstore_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-31: `Bucket.update` and `Bucket.beginUpdateBatch` methods for changing labels, [PR-89](https://github.com/reductstore/reduct-js/pull/89)
 - RS-394: Add query support for browser, [PR-90](https://github.com/reductstore/reduct-js/pull/90)
 
+### Fixed:
+
+- Hanging HEAD requests, [PR-91](https://github.com/reductstore/reduct-js/pull/91)
+
 ## [1.10.1] - 2024-07-01
 
 ### Fixed:

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -345,7 +345,7 @@ export class Bucket {
     const request = head ? this.httpClient.head : this.httpClient.get;
     const { status, headers, data } = await request(
       `/b/${this.name}/${entry}?${param}`,
-      { responseType: "stream" },
+      head ? undefined : { responseType: "stream" },
     );
 
     if (status === 204) {
@@ -410,7 +410,7 @@ export class Bucket {
     const request = head ? this.httpClient.head : this.httpClient.get;
     const { status, headers, data } = await request(
       `/b/${this.name}/${entry}/batch?q=${id}`,
-      { responseType: "stream" },
+      head ? undefined : { responseType: "stream" },
     );
 
     if (status === 204) {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

We use the stream response type for the HEAD requests, they hang in the event loop if a user doesn't call the Record.read() method. This is undetectable.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
