### PR TITLE
RS-418: Implement remove record API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- RS-418: `Bucket.reomveRecord`, `Bucket.beginRemoveBatch` and `Bucket.removeQuery` methods to remove records, [PR-92](https://github.com/reductstore/reduct-js/pull/92)
+
 ## [1.11.0] - 2024-08-20
 
 ### Added:

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -5,11 +5,10 @@ import { BucketInfo } from "./messages/BucketInfo";
 import { EntryInfo } from "./messages/EntryInfo";
 import { LabelMap, ReadableRecord, WritableRecord } from "./Record";
 import { APIError } from "./APIError";
-import { Readable } from "stream";
+import Stream, { Readable } from "stream";
 import { Buffer } from "buffer";
 import { Batch, BatchType } from "./Batch";
 import { isCompatibale } from "./Client";
-import Stream from "stream";
 
 /**
  * Options for querying records
@@ -127,6 +126,15 @@ export class Bucket {
    */
   async removeRecord(entry: string, ts: bigint): Promise<void> {
     await this.httpClient.delete(`/b/${this.name}/${entry}?ts=${ts}`);
+  }
+
+  /**
+   * Remove a batch of records
+   * @param entry {string} name of the entry
+   * @param tsList {BigInt[]} list of timestamps of records in microseconds
+   */
+  async beginRemoveBatch(entry: string): Promise<Batch> {
+    return new Batch(this.name, entry, this.httpClient, BatchType.REMOVE);
   }
 
   /**

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -121,6 +121,15 @@ export class Bucket {
   }
 
   /**
+   * Remove a record
+   * @param entry {string} name of the entry
+   * @param ts {BigInt} timestamp of record in microseconds
+   */
+  async removeRecord(entry: string, ts: bigint): Promise<void> {
+    await this.httpClient.delete(`/b/${this.name}/${entry}?ts=${ts}`);
+  }
+
+  /**
    * Start writing a record into an entry
    * @param entry name of the entry
    * @param options {BigInt | WriteOptions} timestamp in microseconds for the record or options. It is current time if undefined.

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -21,7 +21,7 @@ export interface QueryOptions {
   eachN?: number; //  return each N-th record
   limit?: number; //  limit number of records
   continuous?: boolean; //  await for new records
-  poolInterval?: number; //  interval for pooling new records (only for continue=true)
+  pollInterval?: number; //  interval for polling new records (only for continue=true)
   head?: boolean; //  return only head of the record
 }
 
@@ -138,6 +138,27 @@ export class Bucket {
   }
 
   /**
+   * Remove records by query
+   * @param entry {string} name of the entry
+   * @param start {BigInt} start point of the time period, if undefined, the query starts from the first record
+   * @param stop  {BigInt} stop point of the time period. If undefined, the query stops at the last record
+   * @param QueryOptions {QueryOptions} options for query. You can use only include, exclude, eachS, eachN other options are ignored
+   */
+  async removeQuery(
+    entry: string,
+    start?: bigint,
+    stop?: bigint,
+    QueryOptions?: QueryOptions,
+  ): Promise<void> {
+    const ret = this.parse_query_params(start, stop, QueryOptions);
+
+    const { data } = await this.httpClient.delete(
+      `/b/${this.name}/${entry}/q?${ret.query}`,
+    );
+    return Promise.resolve(data["removed_records"]);
+  }
+
+  /**
    * Start writing a record into an entry
    * @param entry name of the entry
    * @param options {BigInt | WriteOptions} timestamp in microseconds for the record or options. It is current time if undefined.
@@ -234,9 +255,39 @@ export class Bucket {
     stop?: bigint,
     options?: number | QueryOptions,
   ): AsyncGenerator<ReadableRecord> {
-    const params: string[] = [];
+    const ret = this.parse_query_params(start, stop, options);
+
+    const url = `/b/${this.name}/${entry}/q?` + ret.query;
+    const { data, headers } = await this.httpClient.get(url);
+    const { id } = data;
+    const header_api_version = headers["x-reduct-api"];
+    if (isCompatibale("1.5", header_api_version) && !this.isBrowser) {
+      yield* this.fetchAndParseBatchedRecords(
+        entry,
+        id,
+        ret.continuous,
+        ret.pollInterval,
+        ret.head,
+      );
+    } else {
+      yield* this.fetchAndParseSingleRecord(
+        entry,
+        id,
+        ret.continuous,
+        ret.pollInterval,
+        ret.head,
+      );
+    }
+  }
+
+  private parse_query_params(
+    start?: bigint,
+    stop?: bigint,
+    options?: QueryOptions | number,
+  ) {
     let continueQuery = false;
     let poolInterval = 1;
+    const params: string[] = [];
     let head = false;
 
     if (start !== undefined) {
@@ -284,9 +335,9 @@ export class Bucket {
           params.push(`continuous=${options.continuous ? "true" : "false"}`);
           continueQuery = options.continuous;
 
-          if (options.poolInterval !== undefined) {
+          if (options.pollInterval !== undefined) {
             // eslint-disable-next-line prefer-destructuring
-            poolInterval = options.poolInterval;
+            poolInterval = options.pollInterval;
           }
 
           // Set default TTL for continue query as 2 * poolInterval
@@ -294,39 +345,25 @@ export class Bucket {
             params.push(`ttl=${poolInterval * 2}`);
           }
         }
-
+        continueQuery = options.continuous ?? false;
+        poolInterval = options.pollInterval ?? 1;
         head = options.head ?? false;
       }
     }
 
-    const url = `/b/${this.name}/${entry}/q?` + params.join("&");
-    const { data, headers } = await this.httpClient.get(url);
-    const { id } = data;
-    const header_api_version = headers["x-reduct-api"];
-    if (isCompatibale("1.5", header_api_version) && !this.isBrowser) {
-      yield* this.fetchAndParseBatchedRecords(
-        entry,
-        id,
-        continueQuery,
-        poolInterval,
-        head,
-      );
-    } else {
-      yield* this.fetchAndParseSingleRecord(
-        entry,
-        id,
-        continueQuery,
-        poolInterval,
-        head,
-      );
-    }
+    return {
+      continuous: continueQuery,
+      pollInterval: poolInterval,
+      head: head,
+      query: params.join("&"),
+    };
   }
 
   private async *fetchAndParseSingleRecord(
     entry: string,
     id: string,
     continueQuery: boolean,
-    poolInterval: number,
+    pollInterval: number,
     head: boolean,
   ) {
     while (true) {
@@ -337,7 +374,7 @@ export class Bucket {
         if (e instanceof APIError && e.status === 204) {
           if (continueQuery) {
             await new Promise((resolve) =>
-              setTimeout(resolve, poolInterval * 1000),
+              setTimeout(resolve, pollInterval * 1000),
             );
             continue;
           }

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -46,354 +46,380 @@ describe("Bucket", () => {
       .then(() => done());
   });
 
-  it("should get info about bucket", async () => {
-    const bucket = await client.getBucket("bucket");
-    const info: BucketInfo = await bucket.getInfo();
+  describe("general", () => {
+    it("should get info about bucket", async () => {
+      const bucket = await client.getBucket("bucket");
+      const info: BucketInfo = await bucket.getInfo();
 
-    expect(info.name).toEqual("bucket");
-    expect(info.size).toEqual(217n);
-    expect(info.entryCount).toEqual(2n);
-    expect(info.oldestRecord).toEqual(1000_000n);
-    expect(info.latestRecord).toEqual(4000_000n);
-  });
-
-  it("should get/set settings", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    await expect(bucket.getSettings()).resolves.toEqual({
-      maxBlockSize: 64000000n,
-      maxBlockRecords: 256n,
-      quotaSize: 0n,
-      quotaType: QuotaType.NONE,
+      expect(info.name).toEqual("bucket");
+      expect(info.size).toEqual(217n);
+      expect(info.entryCount).toEqual(2n);
+      expect(info.oldestRecord).toEqual(1000_000n);
+      expect(info.latestRecord).toEqual(4000_000n);
     });
 
-    await bucket.setSettings({
-      maxBlockRecords: 1024n,
-      quotaType: QuotaType.FIFO,
-    });
-    await expect(bucket.getSettings()).resolves.toEqual({
-      maxBlockSize: 64000000n,
-      maxBlockRecords: 1024n,
-      quotaSize: 0n,
-      quotaType: QuotaType.FIFO,
-    });
-  });
-
-  it("should get list of entries", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    await expect(bucket.getEntryList()).resolves.toEqual([
-      {
-        blockCount: 1n,
-        latestRecord: 1000000n,
-        name: "entry-1",
-        oldestRecord: 1000000n,
-        recordCount: 1n,
-        size: 90n,
-      },
-      {
-        blockCount: 1n,
-        latestRecord: 4000000n,
-        name: "entry-2",
-        oldestRecord: 2000000n,
-        recordCount: 3n,
-        size: 127n,
-      },
-    ]);
-  });
-
-  it("should read latest record", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    const record = await bucket.beginRead("entry-2");
-
-    expect(record).toMatchObject({ size: 9n, time: 4000000n, last: true });
-    expect((await record.read()).toString()).toEqual("somedata4");
-  });
-
-  it.each([
-    [false, "somedata2"],
-    [true, ""],
-  ])(
-    "should read a record by timestamp (head=%p)",
-    async (head: boolean, content: string) => {
+    it("should get/set settings", async () => {
       const bucket: Bucket = await client.getBucket("bucket");
-      const record = await bucket.beginRead("entry-2", 2000000n, head);
+      await expect(bucket.getSettings()).resolves.toEqual({
+        maxBlockSize: 64000000n,
+        maxBlockRecords: 256n,
+        quotaSize: 0n,
+        quotaType: QuotaType.NONE,
+      });
 
-      expect(record).toMatchObject({ size: 9n, time: 2000000n, last: true });
-      expect(await record.read()).toEqual(Buffer.from(content, "ascii"));
-    },
-  );
+      await bucket.setSettings({
+        maxBlockRecords: 1024n,
+        quotaType: QuotaType.FIFO,
+      });
+      await expect(bucket.getSettings()).resolves.toEqual({
+        maxBlockSize: 64000000n,
+        maxBlockRecords: 1024n,
+        quotaSize: 0n,
+        quotaType: QuotaType.FIFO,
+      });
+    });
 
-  it("should read a record with error if timestamp is wrong", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    await expect(bucket.beginRead("entry-2", 10000_000n)).rejects.toMatchObject(
-      { status: 404 },
+    it("should get list of entries", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      await expect(bucket.getEntryList()).resolves.toEqual([
+        {
+          blockCount: 1n,
+          latestRecord: 1000000n,
+          name: "entry-1",
+          oldestRecord: 1000000n,
+          recordCount: 1n,
+          size: 90n,
+        },
+        {
+          blockCount: 1n,
+          latestRecord: 4000000n,
+          name: "entry-2",
+          oldestRecord: 2000000n,
+          recordCount: 3n,
+          size: 127n,
+        },
+      ]);
+    });
+  });
+
+  describe("read/write", () => {
+    it("should read latest record", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      const record = await bucket.beginRead("entry-2");
+
+      expect(record).toMatchObject({ size: 9n, time: 4000000n, last: true });
+      expect((await record.read()).toString()).toEqual("somedata4");
+    });
+
+    it.each([
+      [false, "somedata2"],
+      [true, ""],
+    ])(
+      "should read a record by timestamp (head=%p)",
+      async (head: boolean, content: string) => {
+        const bucket: Bucket = await client.getBucket("bucket");
+        const record = await bucket.beginRead("entry-2", 2000000n, head);
+
+        expect(record).toMatchObject({ size: 9n, time: 2000000n, last: true });
+        expect(await record.read()).toEqual(Buffer.from(content, "ascii"));
+      },
     );
-  });
 
-  it("should write and read a big blob as streams", async () => {
-    const bigBlob = crypto.randomBytes(2 ** 20);
-
-    const bucket: Bucket = await client.getBucket("bucket");
-    const record = await bucket.beginWrite("big-blob");
-    await record.write(Stream.Readable.from(bigBlob), bigBlob.length);
-
-    const readStream: Stream = (await bucket.beginRead("big-blob")).stream;
-
-    const actual: Buffer = await new Promise((resolve, reject) => {
-      const chunks: Buffer[] = [];
-
-      readStream.on("data", (chunk: Buffer) => chunks.push(chunk));
-      readStream.on("error", (err: Error) => reject(err));
-      readStream.on("end", () => resolve(Buffer.concat(chunks)));
+    it("should read a record with error if timestamp is wrong", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      await expect(
+        bucket.beginRead("entry-2", 10000_000n),
+      ).rejects.toMatchObject({ status: 404 });
     });
 
-    expect(actual.length).toEqual(bigBlob.length);
-    expect(md5(actual)).toEqual(md5(bigBlob));
-  });
+    it("should write and read a big blob as streams", async () => {
+      const bigBlob = crypto.randomBytes(2 ** 20);
 
-  it("should write and read a big blob as buffers", async () => {
-    const bigBlob = crypto.randomBytes(2 ** 20);
+      const bucket: Bucket = await client.getBucket("bucket");
+      const record = await bucket.beginWrite("big-blob");
+      await record.write(Stream.Readable.from(bigBlob), bigBlob.length);
 
-    const bucket: Bucket = await client.getBucket("bucket");
-    const record = await bucket.beginWrite("big-blob");
-    await record.write(bigBlob);
+      const readStream: Stream = (await bucket.beginRead("big-blob")).stream;
 
-    const reader = await bucket.beginRead("big-blob");
+      const actual: Buffer = await new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
 
-    const actual: Buffer = await reader.read();
-    expect(actual.length).toEqual(bigBlob.length);
-    expect(md5(actual)).toEqual(md5(bigBlob));
-  });
+        readStream.on("data", (chunk: Buffer) => chunks.push(chunk));
+        readStream.on("error", (err: Error) => reject(err));
+        readStream.on("end", () => resolve(Buffer.concat(chunks)));
+      });
 
-  it("should query batched big blobs", async () => {
-    const bigBlob1 = crypto.randomBytes(16_000_000);
-    const bigBlob2 = crypto.randomBytes(16_000_000);
-
-    const bucket: Bucket = await client.getBucket("bucket");
-    let record = await bucket.beginWrite("big-blob");
-    await record.write(bigBlob1);
-
-    record = await bucket.beginWrite("big-blob");
-    await record.write(bigBlob2);
-
-    const blobs = await all(bucket.query("big-blob"));
-
-    expect(blobs.length).toEqual(2);
-    expect(md5(await blobs[0].read())).toEqual(md5(bigBlob1));
-    expect(md5(await blobs[1].read())).toEqual(md5(bigBlob2));
-  });
-
-  it("should read write and read labels along with records", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    const record = await bucket.beginWrite("entry-1", {
-      labels: { label1: "label1", label2: 100n, label3: true },
+      expect(actual.length).toEqual(bigBlob.length);
+      expect(md5(actual)).toEqual(md5(bigBlob));
     });
-    await record.write("somedata1");
 
-    const readRecord = await bucket.beginRead("entry-1");
-    expect(readRecord.labels).toEqual({
-      label1: "label1",
-      label2: "100",
-      label3: "true",
+    it("should write and read a big blob as buffers", async () => {
+      const bigBlob = crypto.randomBytes(2 ** 20);
+
+      const bucket: Bucket = await client.getBucket("bucket");
+      const record = await bucket.beginWrite("big-blob");
+      await record.write(bigBlob);
+
+      const reader = await bucket.beginRead("big-blob");
+
+      const actual: Buffer = await reader.read();
+      expect(actual.length).toEqual(bigBlob.length);
+      expect(md5(actual)).toEqual(md5(bigBlob));
+    });
+
+    it("should read write and read labels along with records", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      const record = await bucket.beginWrite("entry-1", {
+        labels: { label1: "label1", label2: 100n, label3: true },
+      });
+      await record.write("somedata1");
+
+      const readRecord = await bucket.beginRead("entry-1");
+      expect(readRecord.labels).toEqual({
+        label1: "label1",
+        label2: "100",
+        label3: "true",
+      });
+    });
+
+    it("should read and write content type of records", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      const record = await bucket.beginWrite("entry-1", {
+        contentType: "text/plain",
+      });
+      await record.write("somedata1");
+
+      const readRecord = await bucket.beginRead("entry-1");
+      expect(readRecord.contentType).toEqual("text/plain");
+    });
+
+    it("should write a batch of records", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      const batch = await bucket.beginWriteBatch("entry-10");
+      batch.add(1000n, "somedata1");
+      batch.add(2000n, "somedata2", "text/plain");
+      batch.add(3000n, "somedata3", undefined, {
+        label1: "value1",
+        label2: "value2",
+      });
+      await batch.write();
+
+      const records: ReadableRecord[] = await all(bucket.query("entry-10"));
+      expect(records.length).toEqual(3);
+
+      expect(records[0]).toMatchObject({
+        time: 1000n,
+        size: 9n,
+        contentType: "application/octet-stream",
+        labels: {},
+      });
+      expect(await records[0].read()).toEqual(
+        Buffer.from("somedata1", "ascii"),
+      );
+
+      expect(records[1]).toMatchObject({
+        time: 2000n,
+        size: 9n,
+        contentType: "text/plain",
+        labels: {},
+      });
+      expect(await records[1].read()).toEqual(
+        Buffer.from("somedata2", "ascii"),
+      );
+
+      expect(records[2]).toMatchObject({
+        time: 3000n,
+        size: 9n,
+        contentType: "application/octet-stream",
+        labels: { label1: "value1", label2: "value2" },
+      });
+      expect(await records[2].read()).toEqual(
+        Buffer.from("somedata3", "ascii"),
+      );
+    });
+
+    it_api("1.7")("should write a batch of records with errors", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+
+      const batch = await bucket.beginWriteBatch("entry-1");
+      batch.add(1000_000n, "somedata1");
+      batch.add(2000n, "somedata2", "text/plain");
+      batch.add(3000n, "somedata3", undefined, {
+        label1: "value1",
+        label2: "value2",
+      });
+
+      const errors = await batch.write();
+      expect(errors.size).toEqual(1);
+      expect(errors.get(1000_000n)).toEqual(
+        new APIError("A record with timestamp 1000000 already exists", 409),
+      );
     });
   });
 
-  it("should read and write content type of records", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    const record = await bucket.beginWrite("entry-1", {
-      contentType: "text/plain",
+  describe("query", () => {
+    it("should query batched big blobs", async () => {
+      const bigBlob1 = crypto.randomBytes(16_000_000);
+      const bigBlob2 = crypto.randomBytes(16_000_000);
+
+      const bucket: Bucket = await client.getBucket("bucket");
+      let record = await bucket.beginWrite("big-blob");
+      await record.write(bigBlob1);
+
+      record = await bucket.beginWrite("big-blob");
+      await record.write(bigBlob2);
+
+      const blobs = await all(bucket.query("big-blob"));
+
+      expect(blobs.length).toEqual(2);
+      expect(md5(await blobs[0].read())).toEqual(md5(bigBlob1));
+      expect(md5(await blobs[1].read())).toEqual(md5(bigBlob2));
     });
-    await record.write("somedata1");
 
-    const readRecord = await bucket.beginRead("entry-1");
-    expect(readRecord.contentType).toEqual("text/plain");
-  });
+    it.each([
+      [false, ["somedata2", "somedata3"]],
+      [true, ["", ""]],
+    ])(
+      "should query records head=%p",
+      async (head: boolean, contents: string[]) => {
+        const bucket: Bucket = await client.getBucket("bucket");
+        const records: ReadableRecord[] = await all(
+          bucket.query("entry-2", undefined, undefined, {
+            head,
+          }),
+        );
 
-  it_api("1.11")("should update labels", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    const ts = 1000_000n;
+        expect(records.length).toEqual(3);
+        expect(records[0].time).toEqual(2_000_000n);
+        expect(records[0].size).toEqual(9n);
+        expect(await records[0].read()).toEqual(
+          Buffer.from(contents[0], "ascii"),
+        );
 
-    await bucket.update("entry-1", ts, { label1: "label1", label2: "" });
-    const readRecord = await bucket.beginRead("entry-1", ts);
-    expect(readRecord.labels).toEqual({
-      label1: "label1",
-      label3: "true",
+        expect(records[1].time).toEqual(3_000_000n);
+        expect(records[1].size).toEqual(9n);
+        expect(await records[1].read()).toEqual(
+          Buffer.from(contents[1], "ascii"),
+        );
+      },
+    );
+
+    it("should query records with parameters", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      let records: ReadableRecord[] = await all(
+        bucket.query("entry-2", 3_000_000n),
+      );
+      expect(records.length).toEqual(2);
+
+      records = await all(bucket.query("entry-2", 2_000_000n, 2_000_001n));
+      expect(records.length).toEqual(1);
+
+      await expect(
+        all(bucket.query("entry-2", undefined, undefined, 0)),
+      ).rejects.toHaveProperty("status", 404);
     });
-  });
 
-  it.each([
-    [false, ["somedata2", "somedata3"]],
-    [true, ["", ""]],
-  ])(
-    "should query records head=%p",
-    async (head: boolean, contents: string[]) => {
+    it_api("1.6")("should query limited number of query", async () => {
       const bucket: Bucket = await client.getBucket("bucket");
       const records: ReadableRecord[] = await all(
-        bucket.query("entry-2", undefined, undefined, {
-          head,
+        bucket.query("entry-2", 0n, undefined, { limit: 1 }),
+      );
+      expect(records.length).toEqual(1);
+    });
+
+    it_api("1.10")("should query a record each 2 s", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      const records: ReadableRecord[] = await all(
+        bucket.query("entry-2", 0n, undefined, { eachS: 2.0 }),
+      );
+      expect(records.length).toEqual(2);
+      expect(records[0].time).toEqual(2_000_000n);
+      expect(records[1].time).toEqual(4_000_000n);
+    });
+
+    it_api("1.10")("should query each 3d record", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      const records: ReadableRecord[] = await all(
+        bucket.query("entry-2", 0n, undefined, { eachN: 3 }),
+      );
+      expect(records.length).toEqual(1);
+      expect(records[0].time).toEqual(2_000_000n);
+    });
+
+    it("should query records with labels", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+
+      let record = await bucket.beginWrite("entry-labels", {
+        labels: { label1: "value1", label2: "value2" },
+      });
+      await record.write("somedata1");
+      record = await bucket.beginWrite("entry-labels", {
+        labels: { label1: "value1", label2: "value3" },
+      });
+      await record.write("somedata1");
+
+      let records: ReadableRecord[] = await all(
+        bucket.query("entry-labels", undefined, undefined, {
+          include: { label1: "value1", label2: "value2" },
         }),
       );
+      expect(records.length).toEqual(1);
+      expect(records[0].labels).toEqual({ label1: "value1", label2: "value2" });
 
-      expect(records.length).toEqual(3);
-      expect(records[0].time).toEqual(2_000_000n);
-      expect(records[0].size).toEqual(9n);
-      expect(await records[0].read()).toEqual(
-        Buffer.from(contents[0], "ascii"),
+      records = await all(
+        bucket.query("entry-labels", undefined, undefined, {
+          exclude: { label1: "value1", label2: "value2" },
+        }),
       );
+      expect(records.length).toEqual(1);
+      expect(records[0].labels).toEqual({ label1: "value1", label2: "value3" });
+    });
+  });
 
-      expect(records[1].time).toEqual(3_000_000n);
-      expect(records[1].size).toEqual(9n);
-      expect(await records[1].read()).toEqual(
-        Buffer.from(contents[1], "ascii"),
+  describe("remove", () => {
+    it_api("1.6")("should remove entry", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      await bucket.removeEntry("entry-1");
+      await expect(bucket.beginRead("entry-1")).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+
+    it_api("1.12")("should remove a record", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      await bucket.removeRecord("entry-2", 2000_000n);
+      await expect(
+        bucket.beginRead("entry-2", 2000_000n),
+      ).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+  });
+
+  describe("update", () => {
+    it_api("1.11")("should update labels in a batch", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+
+      const batch = await bucket.beginUpdateBatch("entry-1");
+      batch.addOnlyLabels(1000_000n, { label1: "value1", label2: "" });
+      batch.addOnlyLabels(20_000_000n, {});
+      const errors = await batch.write();
+      expect(errors.size).toEqual(1);
+      expect(errors.get(20_000_000n)).toEqual(
+        new APIError("No record with timestamp 20000000", 404),
       );
-    },
-  );
-
-  it("should query records with parameters", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    let records: ReadableRecord[] = await all(
-      bucket.query("entry-2", 3_000_000n),
-    );
-    expect(records.length).toEqual(2);
-
-    records = await all(bucket.query("entry-2", 2_000_000n, 2_000_001n));
-    expect(records.length).toEqual(1);
-
-    await expect(
-      all(bucket.query("entry-2", undefined, undefined, 0)),
-    ).rejects.toHaveProperty("status", 404);
-  });
-
-  it_api("1.6")("should query limited number of query", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    const records: ReadableRecord[] = await all(
-      bucket.query("entry-2", 0n, undefined, { limit: 1 }),
-    );
-    expect(records.length).toEqual(1);
-  });
-
-  it_api("1.10")("should query a record each 2 s", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    const records: ReadableRecord[] = await all(
-      bucket.query("entry-2", 0n, undefined, { eachS: 2.0 }),
-    );
-    expect(records.length).toEqual(2);
-    expect(records[0].time).toEqual(2_000_000n);
-    expect(records[1].time).toEqual(4_000_000n);
-  });
-
-  it_api("1.10")("should query each 3d record", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    const records: ReadableRecord[] = await all(
-      bucket.query("entry-2", 0n, undefined, { eachN: 3 }),
-    );
-    expect(records.length).toEqual(1);
-    expect(records[0].time).toEqual(2_000_000n);
-  });
-
-  it("should query records with labels", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-
-    let record = await bucket.beginWrite("entry-labels", {
-      labels: { label1: "value1", label2: "value2" },
-    });
-    await record.write("somedata1");
-    record = await bucket.beginWrite("entry-labels", {
-      labels: { label1: "value1", label2: "value3" },
-    });
-    await record.write("somedata1");
-
-    let records: ReadableRecord[] = await all(
-      bucket.query("entry-labels", undefined, undefined, {
-        include: { label1: "value1", label2: "value2" },
-      }),
-    );
-    expect(records.length).toEqual(1);
-    expect(records[0].labels).toEqual({ label1: "value1", label2: "value2" });
-
-    records = await all(
-      bucket.query("entry-labels", undefined, undefined, {
-        exclude: { label1: "value1", label2: "value2" },
-      }),
-    );
-    expect(records.length).toEqual(1);
-    expect(records[0].labels).toEqual({ label1: "value1", label2: "value3" });
-  });
-
-  it_api("1.6")("should remove entry", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    await bucket.removeEntry("entry-1");
-    await expect(bucket.beginRead("entry-1")).rejects.toMatchObject({
-      status: 404,
-    });
-  });
-
-  it("should write a batch of records", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-    const batch = await bucket.beginWriteBatch("entry-10");
-    batch.add(1000n, "somedata1");
-    batch.add(2000n, "somedata2", "text/plain");
-    batch.add(3000n, "somedata3", undefined, {
-      label1: "value1",
-      label2: "value2",
-    });
-    await batch.write();
-
-    const records: ReadableRecord[] = await all(bucket.query("entry-10"));
-    expect(records.length).toEqual(3);
-
-    expect(records[0]).toMatchObject({
-      time: 1000n,
-      size: 9n,
-      contentType: "application/octet-stream",
-      labels: {},
-    });
-    expect(await records[0].read()).toEqual(Buffer.from("somedata1", "ascii"));
-
-    expect(records[1]).toMatchObject({
-      time: 2000n,
-      size: 9n,
-      contentType: "text/plain",
-      labels: {},
-    });
-    expect(await records[1].read()).toEqual(Buffer.from("somedata2", "ascii"));
-
-    expect(records[2]).toMatchObject({
-      time: 3000n,
-      size: 9n,
-      contentType: "application/octet-stream",
-      labels: { label1: "value1", label2: "value2" },
-    });
-    expect(await records[2].read()).toEqual(Buffer.from("somedata3", "ascii"));
-  });
-
-  it_api("1.7")("should write a batch of records with errors", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-
-    const batch = await bucket.beginWriteBatch("entry-1");
-    batch.add(1000_000n, "somedata1");
-    batch.add(2000n, "somedata2", "text/plain");
-    batch.add(3000n, "somedata3", undefined, {
-      label1: "value1",
-      label2: "value2",
     });
 
-    const errors = await batch.write();
-    expect(errors.size).toEqual(1);
-    expect(errors.get(1000_000n)).toEqual(
-      new APIError("A record with timestamp 1000000 already exists", 409),
-    );
-  });
+    it_api("1.11")("should update labels", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      const ts = 1000_000n;
 
-  it_api("1.11")("should update labels in a batch", async () => {
-    const bucket: Bucket = await client.getBucket("bucket");
-
-    const batch = await bucket.beginUpdateBatch("entry-1");
-    batch.addOnlyLabels(1000_000n, { label1: "value1", label2: "" });
-    batch.addOnlyLabels(20_000_000n, {});
-    const errors = await batch.write();
-    expect(errors.size).toEqual(1);
-    expect(errors.get(20_000_000n)).toEqual(
-      new APIError("No record with timestamp 20000000", 404),
-    );
+      await bucket.update("entry-1", ts, { label1: "label1", label2: "" });
+      const readRecord = await bucket.beginRead("entry-1", ts);
+      expect(readRecord.labels).toEqual({
+        label1: "label1",
+        label3: "true",
+      });
+    });
   });
 });

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -394,6 +394,20 @@ describe("Bucket", () => {
         status: 404,
       });
     });
+
+    it_api("1.12")("should remove a batch of records", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      const batch = await bucket.beginRemoveBatch("entry-2");
+      batch.addOnlyTimestamp(2000_000n);
+      batch.addOnlyTimestamp(3000_000n);
+      batch.addOnlyTimestamp(5000_000n);
+
+      const errors = await batch.write();
+      expect(errors.size).toEqual(1);
+      expect(errors.get(5000_000n)).toEqual(
+        new APIError("No record with timestamp 5000000", 404),
+      );
+    });
   });
 
   describe("update", () => {
@@ -403,6 +417,7 @@ describe("Bucket", () => {
       const batch = await bucket.beginUpdateBatch("entry-1");
       batch.addOnlyLabels(1000_000n, { label1: "value1", label2: "" });
       batch.addOnlyLabels(20_000_000n, {});
+
       const errors = await batch.write();
       expect(errors.size).toEqual(1);
       expect(errors.get(20_000_000n)).toEqual(


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The following methods have been added:

 * Bucket.removeRecord - to remove a single record 
 * Bucket.beginRemoveBatch - to remove a batch of records 
 * Bucket.removeQuery - to remove records within a time range with filtering by labels

### Related issues

reductstore/reductstore#560

### Does this PR introduce a breaking change?


Fixed a typo in the QueryOptions:  poolInterval -> pollInterval.

### Other information:
