### PR TITLE
RS-388: Add Bucket.renameEntry method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-418: `Bucket.reomveRecord`, `Bucket.beginRemoveBatch` and `Bucket.removeQuery` methods to remove records, [PR-92](https://github.com/reductstore/reduct-js/pull/92)
 - RS-389: Support QuotaType.HARD for bucket quotas, [PR-93](https://github.com/reductstore/reduct-js/pull/93)
+- RS-388: Add `Bucket.renameEntry` method to rename entry, [PR-94](https://github.com/reductstore/reduct-js/pull/94)
 
 ## [1.11.0] - 2024-08-20
 

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -233,6 +233,25 @@ export class Bucket {
   }
 
   /**
+   * Rename an entry
+   * @param entry entry name to rename
+   * @param newEntry new entry name
+   */
+  async renameEntry(entry: string, newEntry: string): Promise<void> {
+    await this.httpClient.put(
+      `/b/${this.name}/${entry}/rename`,
+      {
+        new_name: newEntry,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  }
+
+  /**
    * Query records for a time interval as generator
    * @param entry entry name
    * @param entry {string} name of the entry

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -458,4 +458,20 @@ describe("Bucket", () => {
       });
     });
   });
+
+  describe("rename", () => {
+    it_api("1.12")("should rename entry", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      await bucket.renameEntry("entry-1", "entry-1-renamed");
+
+      await expect(bucket.beginRead("entry-1")).rejects.toMatchObject({
+        status: 404,
+      });
+      await expect(bucket.beginRead("entry-1-renamed")).resolves.toMatchObject({
+        size: 9n,
+        time: 1000_000n,
+        last: true,
+      });
+    });
+  });
 });


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The `Bucket.renameEntry` method was added.

### Related issues

https://github.com/reductstore/reductstore/pull/596

### Does this PR introduce a breaking change?

No

### Other information:
