### PR TITLE
RS-628: Support ext parameter in query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           --env RS_API_TOKEN=${{matrix.token}}
           --env RS_LOG_LEVEL=DEBUG
           --env RS_LICENSE_PATH=${{matrix.license}}
+          --env RS_EXT_PATH=/tmp
           -d reduct/store:${{ matrix.reductstore_version }}
 
       - name: Load image with tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- RS-628: Support `ext` parameter in `Bucket.query`, [PR-100](https://github.com/reductstore/reduct-js/pull/100)
+
 ## [1.14.0] - 2025-02-25
 
 ### Added:
 
-- RS-550: Add when condition to replication settings, [PR-98](https://github.com/reductstore/reduct-js/pull/98)
+- RS-550: Add `when` condition to replication settings, [PR-98](https://github.com/reductstore/reduct-js/pull/98)
 
 ## [1.13.0] - 2024-12-04
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ data stored in ReductStore.
 ## Features
 
 - Promise-based API for easy asynchronous programming
-- Support for [ReductStore HTTP API v1.14](https://www.reduct.store/docs/http-api)
+- Support for [ReductStore HTTP API v1.15](https://www.reduct.store/docs/http-api)
 - Token-based authentication for secure access to the database
 - Labeling for read-write operations and querying
 - Batch operations for efficient data processing

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -296,7 +296,7 @@ export class Bucket {
     if (
       options !== undefined &&
       typeof options === "object" &&
-      "when" in options
+      ("when" in options || "ext" in options)
     ) {
       const { data, headers } = await this.httpClient.post(
         `/b/${this.name}/${entry}/q`,

--- a/src/messages/QueryEntry.ts
+++ b/src/messages/QueryEntry.ts
@@ -37,6 +37,9 @@ export interface QueryEntry {
    * If true, the query returns an error if any condition cannot be evaluated
    */
   strict?: boolean;
+
+  /** Additional parameters for extensions */
+  ext?: Record<string, any>;
 }
 
 /**
@@ -69,6 +72,8 @@ export class QueryOptions {
   when?: Record<string, any>;
   /**  strict conditional query */
   strict?: boolean;
+  /** Additional parameters for extensions */
+  ext?: Record<string, any>;
 
   static serialize(queryType: QueryType, data: QueryOptions): QueryEntry {
     return {
@@ -83,6 +88,7 @@ export class QueryOptions {
       when: data.when,
       strict: data.strict,
       only_metadata: data.head,
+      ext: data.ext,
     };
   }
 }

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -397,6 +397,17 @@ describe("Bucket", () => {
         expect(records.length).toEqual(0);
       },
     );
+
+    it_api("1.15")("should query with parameters for extensions", async () => {
+      const bucket: Bucket = await client.getBucket("bucket");
+      await expect(
+        all(
+          bucket.query("entry-1", undefined, undefined, { ext: { test: {} } }),
+        ),
+      ).rejects.toMatchObject({
+        status: 422,
+      });
+    });
   });
 
   describe("remove", () => {

--- a/test/Replication.test.ts
+++ b/test/Replication.test.ts
@@ -44,7 +44,7 @@ describe("Replication", () => {
     const replication = await client.getReplication("test-replication");
     expect(replication.info).toMatchObject({
       name: "test-replication",
-      isActive: false,
+      isActive: true,
       isProvisioned: false,
       pendingRecords: 0n,
     });


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR adds the ext parameter to the Bucket.query method to process data with extensions:

```js
for await (const record of bucket.query("entry-1", undefined, undefined, { ext_name: { param: {} } })) {
}

```
### Related issues

https://github.com/reductstore/reductstore/pull/762

### Does this PR introduce a breaking change?

No

### Other information:
