### PR TITLE
Fix/browser content length compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
+- RS-XXX: Add browser support for update, [PR-xx](https://github.com/reductstore/reduct-js/pull/xx)
 - RS-550: Add when condition to replication settings, [PR-98](https://github.com/reductstore/reduct-js/pull/98)
 
 ## [1.13.0] - 2024-12-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
-- RS-xxx: Add browser support for update, [PR-101](https://github.com/reductstore/reduct-js/pull/101)
+- RS-xxx: Add browser support for edit labels, [PR-101](https://github.com/reductstore/reduct-js/pull/101)
 - RS-550: Add when condition to replication settings, [PR-98](https://github.com/reductstore/reduct-js/pull/98)
 
 ## [1.13.0] - 2024-12-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
-- RS-XXX: Add browser support for update, [PR-xx](https://github.com/reductstore/reduct-js/pull/xx)
+- RS-xxx: Add browser support for update, [PR-101](https://github.com/reductstore/reduct-js/pull/101)
 - RS-550: Add when condition to replication settings, [PR-98](https://github.com/reductstore/reduct-js/pull/98)
 
 ## [1.13.0] - 2024-12-04

--- a/src/Batch.ts
+++ b/src/Batch.ts
@@ -133,7 +133,9 @@ export class Batch {
     let response;
     switch (this.type) {
       case BatchType.WRITE: {
-        headers["Content-Length"] = contentLength.toString();
+        if (typeof window === "undefined") {
+          headers["Content-Length"] = contentLength.toString();
+        }
         headers["Content-Type"] = "application/octet-stream";
 
         const stream = Stream.Readable.from(chunks);
@@ -147,7 +149,9 @@ export class Batch {
         break;
       }
       case BatchType.UPDATE:
-        headers["Content-Length"] = "0";
+        if (typeof window === "undefined") {
+          headers["Content-Length"] = "0";
+        }
         response = await this.httpClient.patch(
           `/b/${this.bucketName}/${this.entryName}/batch`,
           "",
@@ -157,7 +161,9 @@ export class Batch {
         );
         break;
       case BatchType.REMOVE:
-        headers["Content-Length"] = "0";
+        if (typeof window === "undefined") {
+          headers["Content-Length"] = "0";
+        }
         response = await this.httpClient.delete(
           `/b/${this.bucketName}/${this.entryName}/batch`,
           {

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -199,11 +199,15 @@ export class Bucket {
       try {
         const record = await this.beginRead(entry, ts);
         data = await record.read();
-      } catch (e) {}
+      } catch (e) {
+        // Ignore errors if record doesn't exist or can't be read
+      }
 
       try {
         await this.removeRecord(entry, ts);
-      } catch (e) {}
+      } catch (e) {
+        // Ignore errors if record doesn't exist
+      }
 
       const writeRecord = await this.beginWrite(entry, { ts, labels });
       await writeRecord.write(data);

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -325,7 +325,7 @@ export class Bucket {
     if (
       options !== undefined &&
       typeof options === "object" &&
-      "when" in options
+      ("when" in options || "ext" in options)
     ) {
       const { data, headers } = await this.httpClient.post(
         `/b/${this.name}/${entry}/q`,

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -91,19 +91,6 @@ export class Client {
     }
     this.httpClient = axios.create(axiosConfig);
 
-    this.httpClient.interceptors.request.use((config: AxiosRequestConfig) => {
-      if (typeof window !== "undefined" && config.headers) {
-        if (config.headers["Content-Length"] !== undefined) {
-          const contentLength = config.headers["Content-Length"];
-          delete config.headers["Content-Length"];
-          if (contentLength === "0" && !config.data) {
-            config.data = "";
-          }
-        }
-      }
-      return config;
-    });
-
     this.httpClient.interceptors.response.use(
       (response: AxiosResponse) => response,
       async (error: AxiosError) => {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -91,6 +91,19 @@ export class Client {
     }
     this.httpClient = axios.create(axiosConfig);
 
+    this.httpClient.interceptors.request.use((config: AxiosRequestConfig) => {
+      if (typeof window !== "undefined" && config.headers) {
+        if (config.headers["Content-Length"] !== undefined) {
+          const contentLength = config.headers["Content-Length"];
+          delete config.headers["Content-Length"];
+          if (contentLength === "0" && !config.data) {
+            config.data = "";
+          }
+        }
+      }
+      return config;
+    });
+
     this.httpClient.interceptors.response.use(
       (response: AxiosResponse) => response,
       async (error: AxiosError) => {

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -116,9 +116,12 @@ export class WritableRecord {
     const { bucketName, entryName, options } = this;
 
     const headers: Record<string, string> = {
-      "Content-Length": contentLength.toString(),
       "Content-Type": options.contentType ?? "application/octet-stream",
     };
+
+    if (typeof window === "undefined") {
+      headers["Content-Length"] = contentLength.toString();
+    }
 
     for (const [key, value] of Object.entries(options.labels ?? {})) {
       headers[`x-reduct-label-${key}`] = value.toString();


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Modified how Content-Length headers are handled in browser environments:
- Added browser detection in Bucket.update, Record.write, and Batch operations
- Implemented fetch API with empty Blob for browser environments
- Maintained Axios with Content-Length header for Node.js environments

### Related issues

(Add links to related issues)

### Does this PR introduce a breaking change?

No, this PR maintains backward compatibility while adding browser support.

### Other information:

This fix addresses browser security restrictions that prevent setting the Content-Length header directly, which was causing 422 errors when updating labels in browser environments.
