### PR TITLE
Fix browser compatibility by skipping Content-Length header in browse…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
-- RS-xyz: Fixed browser compatibility issues with Content-Length header, [PR-103](https://github.com/reductstore/reduct-js/pull/103)
+- RS-613: Fixed browser compatibility issues with Content-Length header, [PR-103](https://github.com/reductstore/reduct-js/pull/103)
 - RS-628: Support `ext` parameter in `Bucket.query`, [PR-100](https://github.com/reductstore/reduct-js/pull/100)
 
 ## [1.14.0] - 2025-02-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
+- RS-xyz: Fixed browser compatibility issues with Content-Length header, [PR-103](https://github.com/reductstore/reduct-js/pull/103)
 - RS-628: Support `ext` parameter in `Bucket.query`, [PR-100](https://github.com/reductstore/reduct-js/pull/100)
 
 ## [1.14.0] - 2025-02-25

--- a/src/Batch.ts
+++ b/src/Batch.ts
@@ -133,9 +133,7 @@ export class Batch {
     let response;
     switch (this.type) {
       case BatchType.WRITE: {
-        if (typeof window === "undefined") {
-          headers["Content-Length"] = contentLength.toString();
-        }
+        headers["Content-Length"] = contentLength.toString();
         headers["Content-Type"] = "application/octet-stream";
 
         const stream = Stream.Readable.from(chunks);
@@ -149,9 +147,6 @@ export class Batch {
         break;
       }
       case BatchType.UPDATE:
-        if (typeof window === "undefined") {
-          headers["Content-Length"] = "0";
-        }
         response = await this.httpClient.patch(
           `/b/${this.bucketName}/${this.entryName}/batch`,
           "",
@@ -161,9 +156,6 @@ export class Batch {
         );
         break;
       case BatchType.REMOVE:
-        if (typeof window === "undefined") {
-          headers["Content-Length"] = "0";
-        }
         response = await this.httpClient.delete(
           `/b/${this.bucketName}/${this.entryName}/batch`,
           {

--- a/src/Batch.ts
+++ b/src/Batch.ts
@@ -133,7 +133,9 @@ export class Batch {
     let response;
     switch (this.type) {
       case BatchType.WRITE: {
-        headers["Content-Length"] = contentLength.toString();
+        if (typeof window === "undefined") {
+          headers["Content-Length"] = contentLength.toString();
+        }
         headers["Content-Type"] = "application/octet-stream";
 
         const stream = Stream.Readable.from(chunks);
@@ -147,7 +149,9 @@ export class Batch {
         break;
       }
       case BatchType.UPDATE:
-        headers["Content-Length"] = "0";
+        if (typeof window === "undefined") {
+          headers["Content-Length"] = "0";
+        }
         response = await this.httpClient.patch(
           `/b/${this.bucketName}/${this.entryName}/batch`,
           "",
@@ -157,7 +161,9 @@ export class Batch {
         );
         break;
       case BatchType.REMOVE:
-        headers["Content-Length"] = "0";
+        if (typeof window === "undefined") {
+          headers["Content-Length"] = "0";
+        }
         response = await this.httpClient.delete(
           `/b/${this.bucketName}/${this.entryName}/batch`,
           {

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -194,9 +194,11 @@ export class Bucket {
    * @param labels {LabelMap} labels to update
    */
   async update(entry: string, ts: bigint, labels: LabelMap): Promise<void> {
-    const headers: Record<string, string> = {
-      "Content-Length": "0",
-    };
+    const headers: Record<string, string> = {};
+
+    if (typeof window === "undefined") {
+      headers["Content-Length"] = "0";
+    }
 
     for (const [key, value] of Object.entries(labels)) {
       headers[`x-reduct-label-${key}`] = value.toString();

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -196,10 +196,6 @@ export class Bucket {
   async update(entry: string, ts: bigint, labels: LabelMap): Promise<void> {
     const headers: Record<string, string> = {};
 
-    if (typeof window === "undefined") {
-      headers["Content-Length"] = "0";
-    }
-
     for (const [key, value] of Object.entries(labels)) {
       headers[`x-reduct-label-${key}`] = value.toString();
     }

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -116,9 +116,12 @@ export class WritableRecord {
     const { bucketName, entryName, options } = this;
 
     const headers: Record<string, string> = {
-      "Content-Length": contentLength.toString(),
       "Content-Type": options.contentType ?? "application/octet-stream",
     };
+
+    if (typeof window === "undefined") {
+      headers["Content-Length"] = contentLength.toString();
+    }
 
     for (const [key, value] of Object.entries(options.labels ?? {})) {
       headers[`x-reduct-label-${key}`] = value.toString();

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -117,11 +117,8 @@ export class WritableRecord {
 
     const headers: Record<string, string> = {
       "Content-Type": options.contentType ?? "application/octet-stream",
+      "Content-Length": contentLength.toString(),
     };
-
-    if (typeof window === "undefined") {
-      headers["Content-Length"] = contentLength.toString();
-    }
 
     for (const [key, value] of Object.entries(options.labels ?? {})) {
       headers[`x-reduct-label-${key}`] = value.toString();


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Modified Content-Length header handling for browser compatibility:

- Added environment detection in Bucket.update, Record.write, and Batch operations
- Removed Content-Length headers in browser environments
- Maintained Content-Length headers for Node.js environments for backward compatibility

### Related issues

(Add links to related issues)

### Does this PR introduce a breaking change?

No, this PR maintains backward compatibility while adding browser support.

### Other information:

This fix addresses browser security restrictions that prevent setting the Content-Length header directly, which was causing 422 errors when updating labels in browser environments.