### PR TITLE
Fix start and stop parameters for POST query  request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
-- RS-613: Fixed browser compatibility issues with Content-Length header, [PR-103](https://github.com/reductstore/reduct-js/pull/103)
 - RS-628: Support `ext` parameter in `Bucket.query`, [PR-100](https://github.com/reductstore/reduct-js/pull/100)
+
+### Fixed:
+
+- RS-613: Fixed browser compatibility issues with Content-Length header, [PR-103](https://github.com/reductstore/reduct-js/pull/103)
+- Fix `start` and `stop` parameters for POST query request, [PR-104](https://github.com/reductstore/reduct-js/pull/104)
 
 ## [1.14.0] - 2025-02-25
 

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -298,7 +298,7 @@ export class Bucket {
     ) {
       const { data, headers } = await this.httpClient.post(
         `/b/${this.name}/${entry}/q`,
-        QueryOptions.serialize(QueryType.QUERY, options),
+        QueryOptions.serialize(QueryType.QUERY, options, start, stop),
       );
       ({ id } = data);
       header_api_version = headers["x-reduct-api"];

--- a/src/messages/QueryEntry.ts
+++ b/src/messages/QueryEntry.ts
@@ -9,9 +9,9 @@ export interface QueryEntry {
   query_type: string;
 
   /** Start query from (Unix timestamp in microseconds) */
-  start?: number;
+  start?: bigint;
   /** Stop query at (Unix timestamp in microseconds) */
-  stop?: number;
+  stop?: bigint;
 
   /** Include records with label */
   include?: Record<string, string>;
@@ -75,8 +75,15 @@ export class QueryOptions {
   /** Additional parameters for extensions */
   ext?: Record<string, any>;
 
-  static serialize(queryType: QueryType, data: QueryOptions): QueryEntry {
+  static serialize(
+    queryType: QueryType,
+    data: QueryOptions,
+    start?: bigint,
+    stop?: bigint,
+  ): QueryEntry {
     return {
+      start: start,
+      stop: stop,
       query_type: QueryType[queryType],
       ttl: data.ttl,
       include: data.include as Record<string, string>,

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -359,16 +359,35 @@ describe("Bucket", () => {
       const bucket: Bucket = await client.getBucket("bucket");
 
       let record = await bucket.beginWrite("entry-labels", {
+        ts: 1000_000n,
         labels: { score: 10, class: "cat" },
       });
+
       await record.write("somedata1");
+
       record = await bucket.beginWrite("entry-labels", {
+        ts: 2000_000n,
+        labels: { score: 10, class: "cat" },
+      });
+
+      await record.write("somedata1");
+
+      record = await bucket.beginWrite("entry-labels", {
+        ts: 3000_000n,
         labels: { score: 20, class: "dog" },
       });
+
+      await record.write("somedata1");
+
+      record = await bucket.beginWrite("entry-labels", {
+        ts: 4000_000n,
+        labels: { score: 20, class: "dog" },
+      });
+
       await record.write("somedata1");
 
       const records: ReadableRecord[] = await all(
-        bucket.query("entry-labels", undefined, undefined, {
+        bucket.query("entry-labels", 1000_000n, 4000_000n, {
           when: { "&score": { $gt: 10 } },
         }),
       );


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

When a user specifies a `when' condition, the SDK starts using the POST query endpoint, but ignores the start and stop parameters.  The PR fixes the issues and adds a test for this case.


### Related issues

https://github.com/reductstore/web-console/issues/94

### Does this PR introduce a breaking change?

No

### Other information:
