### PR TITLE
Return broken signature Record.read() -> Buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move to fetch API, [PR-99](https://github.com/reductstore/reduct-js/pull/99)
 
+### Fixed:
+
+- Return broken signature `Record.read() -> Buffer`, [PR-105](https://github.com/reductstore/reduct-js/pull/105)
+
 ## [1.5.0] - 2025-05-02
 
 ### Added:

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -40,7 +40,7 @@ export class ReadableRecord {
   /**
    * Read content of record
    */
-  public async read(): Promise<Uint8Array> {
+  public async read(): Promise<Buffer> {
     const reader = this.stream.getReader();
     const chunks: Uint8Array[] = [];
     let done = false;
@@ -58,7 +58,7 @@ export class ReadableRecord {
       out.set(c, offset);
       offset += c.length;
     }
-    return out;
+    return Buffer.from(out);
   }
 
   /**

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -5,11 +5,12 @@ import all from "it-all";
 
 import { Client } from "../src/Client";
 import { Bucket } from "../src/Bucket";
-import { cleanStorage, it_api, makeClient, u8 } from "./utils/Helpers";
+import { cleanStorage, it_api, makeClient } from "./utils/Helpers";
 import { BucketInfo } from "../src/messages/BucketInfo";
 import { QuotaType } from "../src/messages/BucketSettings";
 import { ReadableRecord } from "../src/Record";
 import { APIError } from "../src/APIError";
+import { Buffer } from "buffer";
 
 describe("Bucket", () => {
   const client: Client = makeClient();
@@ -119,7 +120,7 @@ describe("Bucket", () => {
         const record = await bucket.beginRead("entry-2", 2000000n, head);
 
         expect(record).toMatchObject({ size: 9n, time: 2000000n, last: true });
-        expect(await record.read()).toEqual(u8(content));
+        expect(await record.read()).toEqual(Buffer.from(content));
       },
     );
 
@@ -229,7 +230,7 @@ describe("Bucket", () => {
         contentType: "application/octet-stream",
         labels: {},
       });
-      expect(await records[0].read()).toEqual(u8("somedata1"));
+      expect(await records[0].read()).toEqual(Buffer.from("somedata1"));
 
       expect(records[1]).toMatchObject({
         time: 2000n,
@@ -237,7 +238,7 @@ describe("Bucket", () => {
         contentType: "text/plain",
         labels: {},
       });
-      expect(await records[1].read()).toEqual(u8("somedata2"));
+      expect(await records[1].read()).toEqual(Buffer.from("somedata2"));
 
       expect(records[2]).toMatchObject({
         time: 3000n,
@@ -245,7 +246,7 @@ describe("Bucket", () => {
         contentType: "application/octet-stream",
         labels: { label1: "value1", label2: "value2" },
       });
-      expect(await records[2].read()).toEqual(u8("somedata3"));
+      expect(await records[2].read()).toEqual(Buffer.from("somedata3"));
 
       batch.clear();
       expect(batch.size()).toEqual(0n);
@@ -310,11 +311,11 @@ describe("Bucket", () => {
         expect(records.length).toEqual(3);
         expect(records[0].time).toEqual(2_000_000n);
         expect(records[0].size).toEqual(9n);
-        expect(await records[0].read()).toEqual(u8(contents[0]));
+        expect(await records[0].read()).toEqual(Buffer.from(contents[0]));
 
         expect(records[1].time).toEqual(3_000_000n);
         expect(records[1].size).toEqual(9n);
-        expect(await records[1].read()).toEqual(u8(contents[1]));
+        expect(await records[1].read()).toEqual(Buffer.from(contents[1]));
       },
     );
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The compatibility was broken #99 and the method Record.read() returned the `Uint8Array ` type instead of the `Buffer`. The PR returns the original type.

### Related issues

#99

### Does this PR introduce a breaking change?

No

### Other information:
